### PR TITLE
Implement MXFP8 forward kernel for RTX Pro 6000 Blackwell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ pytorch-sphinx-theme/
 # HSTU kernels
 fbgemm_gpu/experimental/hstu/src/hstu_ampere/instantiations/*.cu
 fbgemm_gpu/experimental/hstu/src/hstu_hopper/instantiations/*.cu
+fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/instantiations/*.cu

--- a/fbgemm_gpu/experimental/hstu/CMakeLists.txt
+++ b/fbgemm_gpu/experimental/hstu/CMakeLists.txt
@@ -115,6 +115,15 @@ file(GLOB hstu_hopper_cpp_source_files
 file(GLOB hstu_hopper_cuda_source_files
   src/hstu_hopper/instantiations/*.cu)
 
+# Collect HSTU Blackwell RTX source files
+file(GLOB hstu_blackwell_rtx_cpp_source_files
+  src/hstu_blackwell_rtx/*.cpp
+  src/hstu_blackwell_rtx/*.h)
+
+# Collect HSTU Blackwell RTX GPU source files
+file(GLOB hstu_blackwell_rtx_cuda_source_files
+  src/hstu_blackwell_rtx/instantiations/hstu_fwd_hdim*_e4m3*_sm120*.cu)
+
 # Initialize the combined source file lists
 set(hstu_cpp_source_files "")
 set(hstu_cpp_source_files_gpu "")
@@ -136,19 +145,21 @@ if("9.0" IN_LIST TORCH_CUDA_ARCH_LIST OR "9.0a" IN_LIST TORCH_CUDA_ARCH_LIST)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_90a,code=sm_90a")
 endif()
 
-# Conditionally add SM120 sources (reuses Ampere sources with SM89 tuning)
+# Conditionally add SM120 sources (Blackwell RTX FP8 sources and Ampere BF16/FP16 sources)
 if("12.0" IN_LIST TORCH_CUDA_ARCH_LIST)
-  message(STATUS "HSTU: Selecting Ampere sources for arch 12.0 (SM120, reusing SM89 path)")
+  message(STATUS "HSTU: Selecting Ampere BF16/FP16 and Blackwell RTX FP8 sources for arch 12.0")
   if(NOT "8.0" IN_LIST TORCH_CUDA_ARCH_LIST)
     list(APPEND hstu_cpp_source_files ${hstu_ampere_cpp_source_files})
     list(APPEND hstu_cuda_source_files ${hstu_ampere_cuda_source_files})
   endif()
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_120,code=sm_120")
+  list(APPEND hstu_cpp_source_files ${hstu_blackwell_rtx_cpp_source_files})
+  list(APPEND hstu_cuda_source_files ${hstu_blackwell_rtx_cuda_source_files})
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_120a,code=[sm_120a,compute_120a]")
 endif()
 
 # Check if any sources were selected
-if(NOT hstu_cpp_source_files AND NOT hstu_cpp_source_files_gpu AND NOT "10.0" IN_LIST TORCH_CUDA_ARCH_LIST AND NOT "12.0" IN_LIST TORCH_CUDA_ARCH_LIST)
-  message(WARNING "HSTU: Neither Ampere (8.0) nor Hopper (9.0) architectures found in TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}, would compile both")
+if(NOT hstu_cpp_source_files AND NOT hstu_cpp_source_files_gpu AND NOT "10.0" IN_LIST TORCH_CUDA_ARCH_LIST)
+  message(WARNING "HSTU: No recognized architectures found in TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}, would compile Ampere+Hopper")
   list(APPEND hstu_cpp_source_files ${hstu_ampere_cpp_source_files} ${hstu_hopper_cpp_source_files})
   list(APPEND hstu_cuda_source_files ${hstu_ampere_cuda_source_files} ${hstu_hopper_cuda_source_files})
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_80,code=sm_80 -gencode arch=compute_90a,code=sm_90a")
@@ -172,6 +183,7 @@ if(hstu_cpp_source_files OR hstu_cpp_source_files_gpu)
       ${fbgemm_sources_include_directories}
       ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_ampere
       ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_hopper
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/hstu_blackwell_rtx
     CPU_SRCS
       ${hstu_cpp_source_files}
     GPU_SRCS

--- a/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
+++ b/fbgemm_gpu/experimental/hstu/hstu/cuda_hstu_attention.py
@@ -9,8 +9,37 @@
 
 # pyre-strict
 
+from pathlib import Path
 from typing import Any, Optional, Tuple
+import importlib.util
+
 from .library import *  # noqa: F401, F403
+try:
+    from .hstu_blackwell_rtx.blackwell_rtx_fp8_attention import (
+        pack_descale_to_e8m0x4_int32,
+        quantize_paged_kv_cache_for_block_scale,
+        run_blackwell_rtx_fp8_varlen_fwd,
+    )
+except ModuleNotFoundError:
+    _blackwell_rtx_helper_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "hstu_blackwell_rtx"
+        / "blackwell_rtx_fp8_attention.py"
+    )
+    _blackwell_rtx_spec = importlib.util.spec_from_file_location(
+        "hstu_blackwell_rtx_fp8_attention",
+        _blackwell_rtx_helper_path,
+    )
+    if _blackwell_rtx_spec is None or _blackwell_rtx_spec.loader is None:
+        raise
+    _blackwell_rtx_module = importlib.util.module_from_spec(_blackwell_rtx_spec)
+    _blackwell_rtx_spec.loader.exec_module(_blackwell_rtx_module)
+    pack_descale_to_e8m0x4_int32 = _blackwell_rtx_module.pack_descale_to_e8m0x4_int32
+    quantize_paged_kv_cache_for_block_scale = (
+        _blackwell_rtx_module.quantize_paged_kv_cache_for_block_scale
+    )
+    run_blackwell_rtx_fp8_varlen_fwd = _blackwell_rtx_module.run_blackwell_rtx_fp8_varlen_fwd
 import torch
 import torch.nn as nn
 
@@ -61,7 +90,16 @@ def quantize_for_two_directions(x, seq_offsets, fp8_type=torch.float8_e4m3fn):
 
     return x_quantized, x_descale, xt_quantized, xt_descale, cu_seqlens_xt_descale
 
-def quantize_for_block_scale(x, seq_offsets, block_size=128, fp8_type=torch.float8_e4m3fn):
+def quantize_for_block_scale(
+    x,
+    seq_offsets,
+    block_size=128,
+    fp8_type=torch.float8_e4m3fn,
+    *,
+    scale_mode="seq_block",
+    d_chunk_size=128,
+    round_to_e8m0=False,
+):
     # x: (total_seq, head, dim)
     # q and kv might have diffrent block_size
     if x.dim() != 3:
@@ -71,7 +109,50 @@ def quantize_for_block_scale(x, seq_offsets, block_size=128, fp8_type=torch.floa
     dim = x.size(2)
     fp8_max = 448.0 if fp8_type == torch.float8_e4m3fn else 57344.0
 
-    cu_seqlens_x_descale = torch.zeros(B + 1, dtype=torch.int32, device='cuda')
+    cu_seqlens_x_descale = torch.zeros(B + 1, dtype=torch.int32, device=x.device)
+
+    def prepare_scale(scale):
+        scale = torch.max(
+            scale.to(torch.float32),
+            torch.tensor([1e-6], dtype=torch.float32, device=x.device),
+        )
+        if round_to_e8m0:
+            scale = torch.exp2(torch.ceil(torch.log2(scale)))
+        return scale
+
+    if scale_mode == "token_dchunk":
+        d_chunks = (dim + d_chunk_size - 1) // d_chunk_size
+        x_quantized = torch.empty_like(x, dtype=fp8_type)
+        x_descale_list = []
+
+        with torch.no_grad():
+            for i in range(B):
+                start = int(seq_offsets[i].item())
+                end = int(seq_offsets[i + 1].item())
+                cur_scale_chunks = []
+                for d_chunk in range(d_chunks):
+                    d0 = d_chunk * d_chunk_size
+                    d1 = min(dim, d0 + d_chunk_size)
+                    cur = x[start:end, :, d0:d1]
+                    cur_scale = prepare_scale(
+                        torch.amax(cur.abs(), dim=2).to(torch.float32) / fp8_max
+                    )
+                    x_quantized[start:end, :, d0:d1] = (
+                        cur / cur_scale.unsqueeze(-1)
+                    ).to(fp8_type)
+                    cur_scale_chunks.append(cur_scale)
+                x_descale_list.append(torch.stack(cur_scale_chunks, dim=2))
+                cu_seqlens_x_descale[i + 1] = cu_seqlens_x_descale[i] + (end - start)
+
+        x_descale = torch.cat(x_descale_list, dim=0).permute(1, 0, 2).contiguous()
+        if d_chunks == 1:
+            x_descale = x_descale.squeeze(-1).contiguous()
+        assert x_quantized.shape == x.shape, "assert x_quantized shape must equal to x shape"
+        return x_quantized, x_descale, cu_seqlens_x_descale
+
+    if scale_mode != "seq_block":
+        raise ValueError(f"unsupported quantize_for_block_scale scale_mode: {scale_mode}")
+
     x_quantized_list = []
     x_descale_list = []
 
@@ -90,7 +171,7 @@ def quantize_for_block_scale(x, seq_offsets, block_size=128, fp8_type=torch.floa
                 cur_bs_tensor = cur_bs_tensor
             cur_bs_tensor = cur_bs_tensor.view(actual_len_padding_block_num, block_size, head, dim)
             cur_bs_scale_tensor = torch.amax(cur_bs_tensor.abs(), dim=(1, 3), keepdim=True).to(torch.float32) / fp8_max
-            cur_bs_scale_tensor = torch.max(cur_bs_scale_tensor, torch.tensor([1e-6], dtype=torch.float32, device='cuda'))
+            cur_bs_scale_tensor = prepare_scale(cur_bs_scale_tensor)
             x_descale_list.append(cur_bs_scale_tensor)
             cur_bs_tensor_quantized = (cur_bs_tensor / cur_bs_scale_tensor).to(fp8_type).view(actual_len_padding_block_num * block_size, head, dim)[0:actual_len] #[actual_len_padding_block_num * cur_block_size, head, dim] - > [actual_len, head, dim]
             x_quantized_list.append(cur_bs_tensor_quantized)
@@ -198,7 +279,33 @@ class HstuAttnVarlenFunc(torch.autograd.Function):
 
         major_version = torch.cuda.get_device_capability()[0]
         assert major_version in (8, 9, 10, 12), "Only support sm80, sm90, sm100, and sm120"
-        if major_version == 8 or major_version == 12:
+        if major_version == 12 and quant_mode == 2:
+            out, rab_padded = run_blackwell_rtx_fp8_varlen_fwd(
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                scaling_seqlen,
+                num_contexts,
+                num_targets,
+                target_group_size,
+                window_size,
+                alpha,
+                rab,
+                func,
+                kv_cache,
+                page_offsets,
+                page_ids,
+                last_page_lens,
+                quant_mode,
+                quantize_for_block_scale,
+            )
+        elif major_version == 8 or major_version == 12:
             out, rab_padded = torch.ops.fbgemm.hstu_varlen_fwd_80(
                 q,
                 k,
@@ -508,7 +615,7 @@ class HstuAttnVarlenFunc(torch.autograd.Function):
                 output_dtype,
                 False,  # deterministic
             )
-        else:
+        elif ctx.major_version == 10:
             assert seqused_q is None and seqused_k is None, \
                 "HSTU-Blackwell does not support seqused_q and seqused_k"
             _sm100 = _import_sm100()
@@ -535,6 +642,8 @@ class HstuAttnVarlenFunc(torch.autograd.Function):
                 func,
                 False,  # deterministic
             )
+        else:
+            raise RuntimeError("Blackwell RTX FP8 path is forward-only")
 
         # q & k grad shape
         return (

--- a/fbgemm_gpu/experimental/hstu/hstu/library.py
+++ b/fbgemm_gpu/experimental/hstu/hstu/library.py
@@ -12,6 +12,7 @@
 import logging
 import os
 
+no_fbgemm_gpu: bool = False
 try:
     import fbgemm_gpu  # noqa: F401
 except ImportError:
@@ -54,6 +55,11 @@ if (
             if cap >= (9, 0) and cap < (10, 0):
                 torch.ops.load_library(
                     "//deeplearning/fbgemm/fbgemm_gpu/experimental/hstu/src:hstu_ops_gpu_sm90"
+                )
+
+            if cap >= (12, 0):
+                torch.ops.load_library(
+                    "//deeplearning/fbgemm/fbgemm_gpu/experimental/hstu/src:hstu_ops_gpu_sm120"
                 )
 
 else:

--- a/fbgemm_gpu/experimental/hstu/setup.py
+++ b/fbgemm_gpu/experimental/hstu/setup.py
@@ -21,7 +21,7 @@ import subprocess
 import urllib.request
 import urllib.error
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from src.generate_kernels import generate_kernels_ampere, generate_kernels_hopper
+from src.generate_kernels import generate_kernels_ampere, generate_kernels_hopper, generate_kernels_blackwell
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -197,7 +197,7 @@ if not SKIP_CUDA_BUILD:
             cc_flag.append("arch=compute_80,code=sm_80")
         if "12.0" in arch_list:
             cc_flag.append("-gencode")
-            cc_flag.append("arch=compute_120,code=sm_120")
+            cc_flag.append("arch=compute_120a,code=sm_120a")
 
         # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
         # torch._C._GLIBCXX_USE_CXX11_ABI
@@ -257,7 +257,14 @@ if not SKIP_CUDA_BUILD:
         if "9.0" in arch_list:
             torch_cpp_sources.append("src/hstu_hopper/hstu_ops_gpu.cpp")
             generate_kernels_hopper("src/hstu_hopper/instantiations")
-        cuda_sources = (glob.glob("src/hstu_ampere/instantiations/*.cu") if ("8.0" in arch_list or "12.0" in arch_list) else []) + (glob.glob("src/hstu_hopper/instantiations/*.cu") if "9.0" in arch_list else [])
+        if "12.0" in arch_list:
+            torch_cpp_sources.append("src/hstu_blackwell_rtx/hstu_ops_gpu.cpp")
+            generate_kernels_blackwell("src/hstu_blackwell_rtx/instantiations")
+        cuda_sources = (
+            (glob.glob("src/hstu_ampere/instantiations/*.cu") if ("8.0" in arch_list or "12.0" in arch_list) else [])
+            + (glob.glob("src/hstu_hopper/instantiations/*.cu") if "9.0" in arch_list else [])
+            + (glob.glob("src/hstu_blackwell_rtx/instantiations/hstu_fwd_hdim*_e4m3*_sm120*.cu") if "12.0" in arch_list else [])
+        )
 
         nvcc_flags = [
             "-O3",
@@ -291,6 +298,8 @@ if not SKIP_CUDA_BUILD:
             include_dirs.append(Path(this_dir) / "src" / "hstu_ampere")
         if "9.0" in arch_list:
             include_dirs.append(Path(this_dir) / "src" / "hstu_hopper")
+        if "12.0" in arch_list:
+            include_dirs.append(Path(this_dir) / "src" / "hstu_blackwell_rtx")
 
         sources = None
         if ONLY_COMPILE_SO:
@@ -362,6 +371,9 @@ package_dir = {}
 if "10.0" in arch_list:
     packages.append("hstu.hstu_blackwell")
     package_dir["hstu.hstu_blackwell"] = "src/hstu_blackwell"
+
+packages.append("hstu.hstu_blackwell_rtx")
+package_dir["hstu.hstu_blackwell_rtx"] = "src/hstu_blackwell_rtx"
 
 setup(
     name=PACKAGE_NAME,

--- a/fbgemm_gpu/experimental/hstu/src/generate_kernels.py
+++ b/fbgemm_gpu/experimental/hstu/src/generate_kernels.py
@@ -352,6 +352,73 @@ template void run_hstu_bwd_<90, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>
                     )
 
 
+def generate_kernels_blackwell(install_dir: str):
+    """
+    Generate HSTU forward kernels for Blackwell RTX architecture.
+    This upstream branch only builds the FP8 e4m3 forward path.
+    """
+
+    HEAD_DIMENSIONS_FP8 = (
+        []
+        + ([32] if not DISABLE_HDIM32 else [])
+        + ([64] if not DISABLE_HDIM64 else [])
+        + ([128] if not DISABLE_HDIM128 else [])
+        + ([256] if not DISABLE_HDIM256 else [])
+    )
+    RAB = [""] + (["_rab"] if not DISABLE_RAB else [])
+    MASK = [""]
+    if not DISABLE_LOCAL:
+        MASK += ["_local"]
+    if not DISABLE_CAUSAL:
+        CAUSAL_MASK = ["_causal"]
+        CONTEXT_MASK = [""] + (["_context"] if not DISABLE_CONTEXT else [])
+        TARGET_MASK = [""] + (["_target"] if not DISABLE_TARGET else [])
+        MASK += [f"{c}{x}{t}" for c, x, t in itertools.product(CAUSAL_MASK, CONTEXT_MASK, TARGET_MASK)]
+    if not DISABLE_ARBITRARY:
+        MASK += ["_arbitrary"]
+
+    os.makedirs(install_dir, exist_ok=True)
+
+    blackwell_fwd_file_head = """
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// Splitting different head dimensions, data types and masks to different files to speed up
+// compilation. This file is auto-generated. See generate_kernels.py
+
+#include "hstu_fwd_launch_template.h"
+
+template void run_hstu_fwd_<120, {}, {}, {}, {}, {}, {}, {}, {}, {}>
+                           (Hstu_fwd_params& params, cudaStream_t stream);
+
+    """
+
+    # FP8 (e4m3) kernels
+    if not DISABLE_FP8:
+        for hdim, rab, mask in itertools.product(HEAD_DIMENSIONS_FP8, RAB, MASK):
+            file_name = f"{install_dir}/hstu_fwd_hdim{hdim}_e4m3{rab}{mask}_fn{ARBITRARY_NFUNC}_sm120.cu" if "arbitrary" in mask else f"{install_dir}/hstu_fwd_hdim{hdim}_e4m3{rab}{mask}_sm120.cu"
+            if not os.path.exists(file_name):
+                with open(file_name, "w") as f:
+                    f.write(
+                        blackwell_fwd_file_head.format(
+                            "cutlass::float_e4m3_t",
+                            hdim,
+                            "true" if "_rab" in rab else "false",
+                            "true" if "local" in mask else "false",
+                            "true" if "causal" in mask else "false",
+                            "true" if "context" in mask else "false",
+                            "true" if "target" in mask else "false",
+                            "true" if "arbitrary" in mask else "false",
+                            str(ARBITRARY_NFUNC) if "arbitrary" in mask else "0",
+                        )
+                    )
+
+
 def main() -> None:
     import argparse
 
@@ -377,6 +444,10 @@ def main() -> None:
     if "9.0" in args.arch_list:
         # In OSS, the generated files will be written to hstu_hopper/instantiations
         generate_kernels_hopper(args.install_dir or "hstu_hopper/instantiations")
+
+    if "12.0" in args.arch_list:
+        # In OSS, the generated files will be written to hstu_blackwell_rtx/instantiations
+        generate_kernels_blackwell(args.install_dir or "hstu_blackwell_rtx/instantiations")
 
 
 if __name__ == "__main__":

--- a/fbgemm_gpu/experimental/hstu/src/hstu_ampere/hstu_bwd.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_ampere/hstu_bwd.h
@@ -1290,7 +1290,7 @@ void run_hstu_bwd_80(Hstu_bwd_params& params, cudaStream_t stream) {
   const bool rab_one_head = params.h_rab != params.h && params.h_rab == 1;
   BOOL_SWITCH(rab_one_head, Rab_one_head, [&] {
     static constexpr auto tile_size =
-        flash::get_tile_size_bwd<Arch, kHeadDim, Has_rab>();
+        flash::get_tile_size_bwd<Arch, kHeadDim, Has_rab, Is_arbitrary>();
     static constexpr int kBlockM = std::get<0>(tile_size);
     static constexpr int kBlockN = std::get<1>(tile_size);
     static constexpr int kNWarps = std::get<2>(tile_size);

--- a/fbgemm_gpu/experimental/hstu/src/hstu_ampere/hstu_fwd.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_ampere/hstu_fwd.h
@@ -850,7 +850,7 @@ void run_hstu_fwd_8x(Hstu_fwd_params& params, cudaStream_t stream) {
   INT_SWITCH(params.page_size, Page_Size, [&] {
     static constexpr bool Paged_KV = Page_Size > 0;
     static constexpr auto tile_size =
-        flash::get_tile_size_fwd<Arch, kHeadDim, Has_rab>();
+        flash::get_tile_size_fwd<Arch, kHeadDim, Has_rab, Is_arbitrary>();
     static constexpr int kBlockM = std::get<0>(tile_size);
     static constexpr int kBlockN = Paged_KV? Page_Size : std::get<1>(tile_size);
     static constexpr int kNWarps = std::get<2>(tile_size);

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/__init__.py
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/__init__.py
@@ -1,0 +1,5 @@
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/blackwell_rtx_fp8_attention.py
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/blackwell_rtx_fp8_attention.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+# Portions Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Callable, Optional, Tuple
+
+import torch
+
+
+def _round_up_to_multiple(x: int, multiple: int) -> int:
+    return ((x + multiple - 1) // multiple) * multiple
+
+
+def _int_list(t: torch.Tensor) -> list[int]:
+    return [int(x) for x in t.detach().cpu().tolist()]
+
+
+def _actual_varlen_lengths(
+    cu_seqlens: torch.Tensor,
+    seqused: Optional[torch.Tensor],
+) -> list[int]:
+    if seqused is not None:
+        return _int_list(seqused)
+    cu = _int_list(cu_seqlens)
+    return [cu[i + 1] - cu[i] for i in range(len(cu) - 1)]
+
+
+def _pad_varlen_tensor_to_block(
+    x: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seqused: Optional[torch.Tensor],
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], bool]:
+    actual_lengths = _actual_varlen_lengths(cu_seqlens, seqused)
+    old_cu = _int_list(cu_seqlens)
+    padded_lengths = [
+        _round_up_to_multiple(length, block_size) for length in actual_lengths
+    ]
+    changed = any(
+        (old_cu[i + 1] - old_cu[i]) != padded_lengths[i]
+        for i in range(len(actual_lengths))
+    )
+
+    actual_tensor = torch.tensor(
+        actual_lengths,
+        dtype=torch.int32,
+        device=cu_seqlens.device,
+    )
+    if not changed:
+        return x, cu_seqlens, actual_tensor if seqused is not None else seqused, False
+
+    new_cu_host = [0]
+    for length in padded_lengths:
+        new_cu_host.append(new_cu_host[-1] + length)
+    new_cu = torch.tensor(new_cu_host, dtype=torch.int32, device=cu_seqlens.device)
+    out = torch.zeros((new_cu_host[-1], *x.shape[1:]), dtype=x.dtype, device=x.device)
+    for i, actual in enumerate(actual_lengths):
+        if actual == 0:
+            continue
+        out[new_cu_host[i] : new_cu_host[i] + actual] = x[
+            old_cu[i] : old_cu[i] + actual
+        ]
+    return out.contiguous(), new_cu, actual_tensor, True
+
+
+def _pad_arbitrary_func_to_q_layout(
+    func: Optional[torch.Tensor],
+    old_cu_q: torch.Tensor,
+    new_cu_q: torch.Tensor,
+    actual_q: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    if func is None or actual_q is None:
+        return func
+    old_cu = _int_list(old_cu_q)
+    new_cu = _int_list(new_cu_q)
+    actual = _int_list(actual_q)
+    if old_cu == new_cu:
+        return func
+
+    tail = max(0, int(func.size(-1)) - old_cu[-1])
+    padded = torch.zeros(
+        (*func.shape[:-1], new_cu[-1] + tail),
+        dtype=func.dtype,
+        device=func.device,
+    )
+    for i, length in enumerate(actual):
+        if length == 0:
+            continue
+        padded[..., new_cu[i] : new_cu[i] + length] = func[
+            ..., old_cu[i] : old_cu[i] + length
+        ]
+    return padded.contiguous()
+
+
+def _unpad_varlen_tensor_from_block(
+    x: torch.Tensor,
+    cu_seqlens_padded: torch.Tensor,
+    actual_lengths: torch.Tensor,
+) -> torch.Tensor:
+    cu = _int_list(cu_seqlens_padded)
+    actual = _int_list(actual_lengths)
+    pieces = [
+        x[cu[i] : cu[i] + actual[i]]
+        for i in range(len(actual))
+        if actual[i] > 0
+    ]
+    if not pieces:
+        return x[:0]
+    return torch.cat(pieces, dim=0).contiguous()
+
+
+def _pad_paged_kv_tail_to_page_layout(
+    x: torch.Tensor,
+    cu_seqlens_q_original: torch.Tensor,
+    cu_seqlens_k_original: torch.Tensor,
+    actual_q_lengths: Optional[torch.Tensor],
+    seqused_k: Optional[torch.Tensor],
+    num_targets: Optional[torch.Tensor],
+    last_page_lens: Optional[torch.Tensor],
+    page_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    old_offsets = _int_list(cu_seqlens_q_original)
+    actual_q = (
+        _int_list(actual_q_lengths)
+        if actual_q_lengths is not None
+        else [old_offsets[i + 1] - old_offsets[i] for i in range(len(old_offsets) - 1)]
+    )
+    actual_k = _actual_varlen_lengths(cu_seqlens_k_original, seqused_k)
+    targets = (
+        _int_list(num_targets)
+        if num_targets is not None
+        else [0 for _ in actual_k]
+    )
+    last_pages = (
+        _int_list(last_page_lens)
+        if last_page_lens is not None
+        else [page_size for _ in actual_k]
+    )
+
+    new_offsets = [0]
+    for b, actual_k_len in enumerate(actual_k):
+        target_len = targets[b]
+        actual_q_len = actual_q[b]
+        if target_len > actual_q_len or target_len > actual_k_len:
+            raise ValueError(
+                f"num_targets[{b}]={target_len} exceeds q/k lengths "
+                f"{actual_q_len}/{actual_k_len}"
+            )
+        cache_len = actual_k_len - target_len
+        if target_len > 0:
+            last_page = last_pages[b]
+            if not (1 <= last_page <= page_size):
+                raise ValueError(f"invalid last_page_lens[{b}]={last_page}")
+            if (cache_len + (page_size - last_page)) % page_size != 0:
+                raise ValueError(
+                    "paged target tail must start on a page boundary for Blackwell RTX FP8 TMA"
+                )
+            physical_len = cache_len + (page_size - last_page) + target_len
+        else:
+            physical_len = max(actual_q_len, actual_k_len)
+        new_offsets.append(new_offsets[-1] + _round_up_to_multiple(physical_len, page_size))
+
+    new_cu = torch.tensor(
+        new_offsets,
+        dtype=torch.int32,
+        device=cu_seqlens_q_original.device,
+    )
+    actual_k_tensor = torch.tensor(
+        actual_k,
+        dtype=torch.int32,
+        device=cu_seqlens_q_original.device,
+    )
+    out = x.new_zeros((new_offsets[-1], *x.shape[1:]))
+
+    for b, actual_q_len in enumerate(actual_q):
+        old_start = old_offsets[b]
+        new_start = new_offsets[b]
+        target_len = targets[b]
+        new_history_len = actual_q_len - target_len
+        if new_history_len > 0:
+            out[new_start : new_start + new_history_len] = x[
+                old_start : old_start + new_history_len
+            ]
+
+        if target_len > 0:
+            last_page = last_pages[b]
+            cache_len = actual_k[b] - target_len
+            target_start = new_start + cache_len + (page_size - last_page)
+            target_end = target_start + target_len
+            if target_end > new_offsets[b + 1]:
+                raise ValueError(
+                    "paged target tail does not fit in padded physical K/V layout"
+                )
+            src_start = old_start + new_history_len
+            out[target_start:target_end] = x[src_start : src_start + target_len]
+
+    return out.contiguous(), new_cu, actual_k_tensor
+
+
+def _pad_rab_to_paged_kv_layout(
+    rab: Optional[torch.Tensor],
+    cu_seqlens_k_original: torch.Tensor,
+    seqused_k_actual: Optional[torch.Tensor],
+    num_targets: Optional[torch.Tensor],
+    last_page_lens: Optional[torch.Tensor],
+    page_size: int,
+) -> Optional[torch.Tensor]:
+    if rab is None or num_targets is None or last_page_lens is None:
+        return rab
+
+    actual_k = _actual_varlen_lengths(cu_seqlens_k_original, seqused_k_actual)
+    targets = _int_list(num_targets)
+    last_pages = _int_list(last_page_lens)
+    max_logical = int(rab.size(-1))
+    gaps: list[int] = []
+    max_physical = max_logical
+    for b, actual_k_len in enumerate(actual_k):
+        target_len = targets[b]
+        gap = 0
+        if target_len > 0:
+            last_page = last_pages[b]
+            if not (1 <= last_page <= page_size):
+                raise ValueError(f"invalid last_page_lens[{b}]={last_page}")
+            gap = page_size - last_page
+        gaps.append(gap)
+        max_physical = max(max_physical, actual_k_len + gap)
+
+    if max_physical == max_logical and all(gap == 0 for gap in gaps):
+        return rab
+
+    out = rab.new_zeros((rab.size(0), rab.size(1), max_physical, max_physical))
+    for b, actual_k_len in enumerate(actual_k):
+        target_len = targets[b]
+        gap = gaps[b]
+        if target_len <= 0 or gap == 0:
+            out[b, :, :max_logical, :max_logical] = rab[b]
+            continue
+        history_len = actual_k_len - target_len
+        if history_len > 0:
+            out[b, :, :max_logical, :history_len] = rab[b, :, :, :history_len]
+        src_end = min(actual_k_len, max_logical)
+        if src_end > history_len:
+            dst_start = history_len + gap
+            dst_end = dst_start + (src_end - history_len)
+            out[b, :, :max_logical, dst_start:dst_end] = rab[
+                b, :, :, history_len:src_end
+            ]
+    return out.contiguous()
+
+
+def _pack_descale_to_e8m0x4_int32(descale: torch.Tensor) -> torch.Tensor:
+    s = torch.clamp(descale.to(torch.float32), min=1e-10)
+    exp_biased = torch.clamp(torch.ceil(torch.log2(s)) + 127.0, 0.0, 255.0).to(
+        torch.uint8
+    )
+    if exp_biased.dim() == 3:
+        if exp_biased.size(-1) > 4:
+            raise ValueError(
+                f"e8m0x4 packing supports at most 4 D chunks, got {exp_biased.size(-1)}"
+            )
+        padded = torch.zeros(
+            (*exp_biased.shape[:-1], 4),
+            dtype=torch.uint8,
+            device=exp_biased.device,
+        )
+        padded[..., : exp_biased.size(-1)] = exp_biased
+        word = padded.to(torch.int32)
+        return (
+            word[..., 0]
+            | (word[..., 1] << 8)
+            | (word[..., 2] << 16)
+            | (word[..., 3] << 24)
+        ).contiguous()
+    word = exp_biased.to(torch.int32)
+    return (word | (word << 8) | (word << 16) | (word << 24)).contiguous()
+
+
+def quantize_paged_kv_cache_for_block_scale(
+    kv_cache: torch.Tensor,
+    block_size: int,
+    fp8_type=torch.float8_e4m3fn,
+    quantize_for_block_scale_fn: Optional[Callable[..., tuple[torch.Tensor, torch.Tensor, torch.Tensor]]] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if kv_cache.dim() != 5:
+        raise ValueError("kv_cache must have shape [pages, 2, page_size, heads, dim]")
+    if kv_cache.size(1) != 2:
+        raise ValueError("kv_cache second dimension must be 2")
+    if kv_cache.size(2) != block_size:
+        raise ValueError(f"kv_cache page_size must equal block_size={block_size}")
+    if quantize_for_block_scale_fn is None:
+        from hstu.cuda_hstu_attention import quantize_for_block_scale
+        quantize_for_block_scale_fn = quantize_for_block_scale
+    pages, _, page_size, heads, dim = kv_cache.shape
+
+    with torch.no_grad():
+        k_cache = kv_cache[:, 0].contiguous()
+        v_cache = kv_cache[:, 1].contiguous()
+        flat_offsets = torch.tensor(
+            [0, pages * page_size],
+            dtype=torch.int32,
+            device=kv_cache.device,
+        )
+
+        k_fp8_flat, k_descale, _ = quantize_for_block_scale_fn(
+            k_cache.view(pages * page_size, heads, dim),
+            flat_offsets,
+            fp8_type=fp8_type,
+            scale_mode="token_dchunk",
+            d_chunk_size=128,
+            round_to_e8m0=True,
+        )
+        v_fp8_flat, v_descale, _ = quantize_for_block_scale_fn(
+            v_cache.view(pages * page_size, heads, dim),
+            flat_offsets,
+            block_size=block_size,
+            fp8_type=fp8_type,
+            scale_mode="seq_block",
+            round_to_e8m0=True,
+        )
+
+        kv_cache_fp8 = torch.empty_like(kv_cache, dtype=fp8_type)
+        kv_cache_fp8[:, 0] = k_fp8_flat.view(pages, page_size, heads, dim)
+        kv_cache_fp8[:, 1] = v_fp8_flat.view(pages, page_size, heads, dim)
+
+    return (
+        kv_cache_fp8.contiguous(),
+        _pack_descale_to_e8m0x4_int32(k_descale),
+        _pack_descale_to_e8m0x4_int32(v_descale).repeat_interleave(block_size, dim=1),
+    )
+
+
+def pack_descale_to_e8m0x4_int32(descale: torch.Tensor) -> torch.Tensor:
+    return _pack_descale_to_e8m0x4_int32(descale)
+
+
+def _blackwell_rtx_block_sizes(is_paged_kv: bool, kv_cache: Optional[torch.Tensor]) -> tuple[int, int]:
+    if is_paged_kv:
+        assert kv_cache is not None
+        return 128, int(kv_cache.shape[2])
+    return 128, 64
+
+
+def run_blackwell_rtx_fp8_varlen_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    seqused_q: Optional[torch.Tensor],
+    seqused_k: Optional[torch.Tensor],
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    scaling_seqlen: int,
+    num_contexts: Optional[torch.Tensor],
+    num_targets: Optional[torch.Tensor],
+    target_group_size: int,
+    window_size: Tuple[int, int],
+    alpha: float,
+    rab: Optional[torch.Tensor],
+    func: Optional[torch.Tensor],
+    kv_cache: Optional[torch.Tensor],
+    page_offsets: Optional[torch.Tensor],
+    page_ids: Optional[torch.Tensor],
+    last_page_lens: Optional[torch.Tensor],
+    quant_mode: Optional[int],
+    quantize_for_block_scale_fn: Callable[..., tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if quant_mode != 2:
+        raise ValueError("Blackwell RTX path only supports FP8 quant_mode=2 forward")
+
+    is_paged_kv = (
+        kv_cache is not None
+        and page_offsets is not None
+        and page_ids is not None
+        and last_page_lens is not None
+    )
+    bm, bn = _blackwell_rtx_block_sizes(is_paged_kv, kv_cache)
+    if is_paged_kv and (q.shape[-1] not in (32, 64, 128, 256) or bn != 64):
+        raise ValueError(
+            "Blackwell RTX FP8 paged KV requires headDim 32/64/128/256 and page_size=64"
+        )
+
+    blackwell_rtx_fp8_unpad_q: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    original_cu_seqlens_q = cu_seqlens_q
+    q, cu_seqlens_q, seqused_q_actual, q_was_padded = _pad_varlen_tensor_to_block(
+        q,
+        cu_seqlens_q,
+        seqused_q,
+        bm,
+    )
+    if q_was_padded:
+        func = _pad_arbitrary_func_to_q_layout(
+            func,
+            original_cu_seqlens_q,
+            cu_seqlens_q,
+            seqused_q_actual,
+        )
+        seqused_q = seqused_q_actual
+        blackwell_rtx_fp8_unpad_q = (cu_seqlens_q, seqused_q_actual)
+
+    if is_paged_kv:
+        original_cu_seqlens_k = cu_seqlens_k
+        k, cu_seqlens_k, seqused_k_actual = _pad_paged_kv_tail_to_page_layout(
+            k,
+            original_cu_seqlens_q,
+            original_cu_seqlens_k,
+            seqused_q_actual,
+            seqused_k,
+            num_targets,
+            last_page_lens,
+            bn,
+        )
+        v, _, _ = _pad_paged_kv_tail_to_page_layout(
+            v,
+            original_cu_seqlens_q,
+            original_cu_seqlens_k,
+            seqused_q_actual,
+            seqused_k,
+            num_targets,
+            last_page_lens,
+            bn,
+        )
+        rab = _pad_rab_to_paged_kv_layout(
+            rab,
+            original_cu_seqlens_k,
+            seqused_k_actual,
+            num_targets,
+            last_page_lens,
+            bn,
+        )
+        seqused_k = seqused_k_actual
+        kv_quant_offsets = cu_seqlens_k
+    else:
+        original_cu_seqlens_k = cu_seqlens_k
+        k, cu_seqlens_k, seqused_k_actual, k_was_padded = _pad_varlen_tensor_to_block(
+            k,
+            cu_seqlens_k,
+            seqused_k,
+            bn,
+        )
+        v, _, _, _ = _pad_varlen_tensor_to_block(
+            v,
+            original_cu_seqlens_k,
+            seqused_k,
+            bn,
+        )
+        if k_was_padded:
+            seqused_k = seqused_k_actual
+        kv_quant_offsets = cu_seqlens_k
+
+    q, q_descale, cu_seqlens_q_block_descale = quantize_for_block_scale_fn(
+        q,
+        cu_seqlens_q,
+        scale_mode="token_dchunk",
+        d_chunk_size=128,
+        round_to_e8m0=True,
+    )
+    k, k_descale, cu_seqlens_kv_block_descale = quantize_for_block_scale_fn(
+        k,
+        kv_quant_offsets,
+        scale_mode="token_dchunk",
+        d_chunk_size=128,
+        round_to_e8m0=True,
+    )
+    v, v_descale, cu_seqlens_v_block_descale = quantize_for_block_scale_fn(
+        v,
+        kv_quant_offsets,
+        block_size=bn,
+        scale_mode="seq_block",
+        round_to_e8m0=True,
+    )
+    sf_q_packed = _pack_descale_to_e8m0x4_int32(q_descale)
+    sf_k_packed = _pack_descale_to_e8m0x4_int32(k_descale)
+    sf_v_packed = _pack_descale_to_e8m0x4_int32(v_descale).repeat_interleave(
+        bn,
+        dim=1,
+    )
+    if is_paged_kv:
+        assert kv_cache is not None
+        kv_cache, sf_k_cache_packed, sf_v_cache_packed = quantize_paged_kv_cache_for_block_scale(
+            kv_cache,
+            block_size=bn,
+            quantize_for_block_scale_fn=quantize_for_block_scale_fn,
+        )
+        sf_k_packed = torch.cat([sf_k_cache_packed, sf_k_packed], dim=1).contiguous()
+        sf_v_packed = torch.cat([sf_v_cache_packed, sf_v_packed], dim=1).contiguous()
+
+    rab_kernel = rab.to(torch.bfloat16) if rab is not None and rab.dtype == torch.float16 else rab
+    out, rab_padded = torch.ops.fbgemm.hstu_varlen_fwd_120(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqused_q,
+        seqused_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        scaling_seqlen,
+        num_contexts,
+        num_targets,
+        target_group_size,
+        window_size[0],
+        window_size[1],
+        alpha,
+        rab_kernel,
+        func,
+        quant_mode if quant_mode is not None else -1,
+        q_descale,
+        k_descale,
+        v_descale,
+        sf_q_packed,
+        sf_k_packed,
+        sf_v_packed,
+        cu_seqlens_q_block_descale,
+        cu_seqlens_kv_block_descale,
+        cu_seqlens_v_block_descale,
+        kv_cache,
+        page_offsets,
+        page_ids,
+        last_page_lens,
+    )
+    if blackwell_rtx_fp8_unpad_q is not None:
+        out = _unpad_varlen_tensor_from_block(
+            out,
+            blackwell_rtx_fp8_unpad_q[0],
+            blackwell_rtx_fp8_unpad_q[1],
+        )
+    return out, rab_padded

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/blackwell_rtx_qmma_builder.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/blackwell_rtx_qmma_builder.h
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// HSTU-local minimal subset of the Blackwell RTX block-scaled GEMM builder.
+//
+// Extracted from:
+//   6KD_fp8_block_scale/kernels/include/sm120_blockscaled_gemm/sm120_blockscaled_utils.cuh
+//
+// Only the members consumed by hstu_fwd_kernel_fp8_ws.h (WS FP8 path) are included:
+//   - TiledMma / MmaAtom (Blackwell RTX block-scaled QMMA)
+//   - SmemCopyAtomA/B/SF + SmemLayoutAtomA/B + SmemLayoutSFA/SFB
+//   - partition_fragment_SFA/B, get_layoutSFA/B_TV, transform_fragment_for_qmma
+//
+// Intentionally omitted: TMA descriptors, TMA transaction bytes, SharedStorage,
+// BarrierStorage, SmemLayoutA/B (multi-stage), scheduler helpers, padded-offset utils.
+
+#pragma once
+
+#include "cute/atom/mma_atom.hpp"
+#include <cute/atom/copy_traits_sm75.hpp>     // SM75_U32x4_LDSM_N
+#include <cute/atom/mma_traits_sm90_gmma.hpp> // GMMA::Layout_K_SW128_Atom
+#include <cute/atom/mma_traits_sm120.hpp>     // SM120::BLOCKSCALED::SM120_16x8x32_TN_VS
+#include <cute/config.hpp>
+#include <cute/tensor.hpp>
+#include <cutlass/numeric_types.h>            // float_e4m3_t, float_ue8m0_t
+#include <type_traits>
+
+namespace hstu {
+
+using namespace cute;
+
+// Minimal HSTU-local subset of the Blackwell RTX block-scaled GEMM builder.
+//
+// Template parameters match the original to preserve call-site compatibility:
+//   TileM_  = kBlockM  (128 in HSTU)
+//   TileN_  = kBlockN  (128 for GEMM1) or kHeadDim (128 for GEMM2)
+//   Stages_ = pipeline stages (fixed at 4 in WS kernel)
+template <int TileM_ = 32, int TileN_ = 128, int Stages_ = 4>
+struct BlackwellRtxQmmaBuilder {
+  using ElementA         = cutlass::float_e4m3_t;
+  using ElementB         = cutlass::float_e4m3_t;
+  using ElementSFLoad    = int32_t;                // 4 e8m0 values packed per int32
+  using ElementSFCompute = cutlass::float_ue8m0_t; // scale type consumed by QMMA atom
+  using ElementAccum     = float;
+
+  static constexpr int AB_Stages      = Stages_;
+  static constexpr int SF_Stages      = 1;
+  static constexpr int kTileM         = TileM_;
+  static constexpr int kTileN         = TileN_;
+  static constexpr int kTileSF        = 1;
+  static constexpr int kTileK         = 128;
+  static constexpr int kNumTileKPerSF = 512 / kTileK;
+  static constexpr int kNumStagePerSF = kNumTileKPerSF / AB_Stages;
+  static_assert(
+      kNumStagePerSF > 0 && kNumStagePerSF <= 2,
+      "kNumStagePerSF must be 1 or 2");
+
+  using TileShape      = Shape<Int<kTileM>, Int<kTileN>, Int<kTileK>>;
+  using ScaleTileShape = Shape<Int<kTileM>, Int<kTileN>, Int<kTileSF>>;
+
+  // ====== MMA atom and tiled MMA ======
+  // Replicates the reference block-scaled GEMM builder's TiledMma exactly.
+  // AtomLayout <_2,_4,_1>: 2×4 warp grid (8 warps in the math warpgroup).
+  // PermMmaTileN swizzles 128-wide N-tiles for Blackwell RTX QMMA optimal bank layout.
+  // The 32/64-wide cases use a linear N tile; callers with hand-written
+  // fragment placement must branch on kTileN because the N-atom order changes.
+  using PermMmaTileM = Int<32>;
+  using PermMmaTileN = std::conditional_t<
+      (kTileN == 32),
+      Int<32>,
+      std::conditional_t<
+          (kTileN == 64),
+          Int<64>,
+          Layout<Shape<_8, _4, _4>, Stride<_1, _32, _8>>>>;
+  using PermMmaTileK = Underscore;
+
+  using MmaAtom = MMA_Atom<SM120::BLOCKSCALED::SM120_16x8x32_TN_VS<
+      ElementA,
+      ElementB,
+      ElementAccum,
+      ElementSFCompute,
+      32>>;
+
+  using TiledMma = TiledMMA<
+      MmaAtom,
+      Layout<Shape<_8, _1, _1>, Stride<_1, _0, _0>>,
+      Tile<PermMmaTileM, PermMmaTileN, PermMmaTileK>>;
+
+  static_assert(
+      kTileM % cute::size(PermMmaTileM{}) == 0,
+      "TileM must be divisible by PermMmaTileM (32)");
+  static_assert(
+      kTileN % cute::size(PermMmaTileN{}) == 0,
+      "TileN must be divisible by PermMmaTileN");
+
+  static constexpr int kNumMathThreads = size(typename TiledMma::ThrLayoutVMNK{});
+  static constexpr int kNumMathWarps   = kNumMathThreads / 32;
+
+  // ====== SMEM → RF copy atoms ======
+  // SM75_U32x4_LDSM_N: ldmatrix.x4 in K-inner layout (required by TiledMma).
+  using SmemCopyAtomA  = Copy_Atom<SM75_U32x4_LDSM_N, ElementA>;
+  using SmemCopyAtomB  = Copy_Atom<SM75_U32x4_LDSM_N, ElementB>;
+  // AutoVectorizingCopy for scale factors (int32, 4-byte aligned LDS).
+  using SmemCopyAtomSF = Copy_Atom<AutoVectorizingCopy, ElementSFLoad>;
+
+  // ====== SMEM layout atoms ======
+  // K_SW128: 8-row × 128-element swizzled atom, K-inner.
+  // Required for SM75_U32x4_LDSM_N (ldmatrix.x4 requires K-inner layout).
+  using SmemLayoutAtomA = GMMA::Layout_K_SW128_Atom<ElementA>;
+  using SmemLayoutAtomB = GMMA::Layout_K_SW128_Atom<ElementB>;
+
+  // ====== Scale factor SMEM layouts ======
+  // SFA: [kTileM, kTileSF=1] single-stage, used for Q-side (GEMM1) and P-side (GEMM2) scales.
+  // SFB: [kTileN, kTileSF=1] single-stage, used for K-side (GEMM1) and V-side (GEMM2) scales.
+  using SmemLayoutAtomSFA = decltype(
+      make_ordered_layout(select<0, 2>(ScaleTileShape{}), Step<_1, _2>{}));
+
+  using SmemLayoutAtomSFB = decltype(
+      make_ordered_layout(select<1, 2>(ScaleTileShape{}), Step<_1, _2>{}));
+
+  using SmemLayoutSFA = decltype(tile_to_shape(
+      SmemLayoutAtomSFA{},
+      make_shape(
+          shape<0>(ScaleTileShape{}),
+          shape<2>(ScaleTileShape{}),
+          Int<SF_Stages>{}),
+      Step<_1, _2, _3>{}));
+
+  using SmemLayoutSFB = decltype(tile_to_shape(
+      SmemLayoutAtomSFB{},
+      make_shape(
+          shape<1>(ScaleTileShape{}),
+          shape<2>(ScaleTileShape{}),
+          Int<SF_Stages>{}),
+      Step<_1, _2, _3>{}));
+
+  // ====== Scale factor partition helpers ======
+
+  // Internal: partition SFA tensor into (ThrV, (ThrM, ThrK)) x (FrgV, (RestM, RestK)).
+  // AtomLayoutSFA_TV encodes per-atom thread<->value mapping; stride _0 in second dim
+  // means 16 effective threads (from 2x2x8=32 logical) due to mode collapse.
+  template <class SFATensor, class Atom, class TiledThr, class TiledPerm>
+  CUTE_HOST_DEVICE static constexpr auto
+  thrfrg_SFA(SFATensor&& sfatensor, TiledMMA<Atom, TiledThr, TiledPerm>& mma) {
+    CUTE_STATIC_ASSERT_V(rank(sfatensor) >= Int<2>{});
+
+    auto permutation_mnk = TiledPerm{};
+    auto t_tile          = make_tile(get<0>(permutation_mnk), _1{});
+    auto tiled_sfa       = logical_divide(sfatensor, t_tile);
+
+    using AtomShape_MNK = typename Atom::Shape_MNK;
+    auto atom_tile      = make_tile(
+        make_layout(size<0>(AtomShape_MNK{})),
+        make_layout(_1{}));
+    auto tiled_atom_sfa = zipped_divide(tiled_sfa, atom_tile);
+
+    using AtomLayoutSFA_TV =
+        Layout<Shape<Shape<_2, _2, _8>, _1>, Stride<Stride<_8, _0, _1>, _16>>;
+    auto tv_atom_sfa = tiled_atom_sfa.compose(AtomLayoutSFA_TV{}, _);
+
+    auto thr_layout_vmnk = mma.get_thr_layout_vmnk();
+    auto thr_tile        = make_tile(
+        _,
+        make_tile(
+            make_layout(size<1>(thr_layout_vmnk)),
+            make_layout(size<3>(thr_layout_vmnk))));
+    return zipped_divide(tv_atom_sfa, thr_tile);
+  }
+
+  // Returns a register fragment for SFA matching the per-thread MMA partition.
+  template <class SFATensor, class ThrMma>
+  CUTE_HOST_DEVICE static constexpr auto
+  partition_fragment_SFA(SFATensor&& sfatensor, ThrMma& thread_mma) {
+    auto thr_tensor = make_tensor(
+        static_cast<SFATensor&&>(sfatensor).data(),
+        thrfrg_SFA(sfatensor.layout(), thread_mma));
+    auto thr_vmnk = thread_mma.thr_vmnk_;
+    auto thr_vmk  = make_coord(
+        get<0>(thr_vmnk),
+        make_coord(get<1>(thr_vmnk), get<3>(thr_vmnk)));
+    auto partition_SFA =
+        thr_tensor(thr_vmk, make_coord(_, repeat<rank<1, 1>(thr_tensor)>(_)));
+    return make_fragment_like<ElementSFLoad>(partition_SFA);
+  }
+
+  // Returns the SFA thread<->value layout for use with make_tiled_copy_impl.
+  template <class TiledMmaType>
+  CUTE_HOST_DEVICE static constexpr auto
+  get_layoutSFA_TV(TiledMmaType& mma) {
+    auto tile_shape_mnk  = tile_shape(mma);
+    auto ref_A           = make_layout(make_shape(size<0>(tile_shape_mnk), _1{}));
+    auto thr_tensor      = thrfrg_SFA(ref_A, mma);
+    auto thr_layout_vmnk = mma.get_thr_layout_vmnk();
+    // SFA strides: M-direction contributes (Int<1>{}), K-direction is collapsed (Int<0>{}).
+    auto atile = make_tile(
+        _,
+        make_tile(
+            make_layout(
+                make_shape(size<1>(thr_layout_vmnk), size<2>(thr_layout_vmnk)),
+                make_stride(Int<1>{}, Int<0>{})),
+            _));
+    auto tv_sfa         = thr_tensor.compose(atile, _);
+    auto thridx_2_thrid = right_inverse(thr_layout_vmnk);
+    return tv_sfa.compose(thridx_2_thrid, _);
+  }
+
+  // Internal: partition SFB tensor into (ThrV, (ThrN, ThrK)) x (FrgV, (RestN, RestK)).
+  // AtomLayoutSFB_TV: 4x8=32 logical threads, 8 effective (stride _0 collapses first dim).
+  template <class SFBTensor, class Atom, class TiledThr, class TiledPerm>
+  CUTE_HOST_DEVICE static constexpr auto
+  thrfrg_SFB(SFBTensor&& sfbtensor, TiledMMA<Atom, TiledThr, TiledPerm>& mma) {
+    CUTE_STATIC_ASSERT_V(rank(sfbtensor) >= Int<2>{});
+
+    auto permutation_mnk = TiledPerm{};
+    auto t_tile          = make_tile(get<1>(permutation_mnk), _1{});
+    auto tiled_sfb       = logical_divide(sfbtensor, t_tile);
+
+    using AtomShape_MNK = typename Atom::Shape_MNK;
+    auto atom_tile      = make_tile(
+        make_layout(size<1>(AtomShape_MNK{})),
+        make_layout(_1{}));
+    auto tiled_atom_sfb = zipped_divide(tiled_sfb, atom_tile);
+
+    using AtomLayoutSFB_TV =
+        Layout<Shape<Shape<_4, _8>, _1>, Stride<Stride<_0, _1>, _8>>;
+    auto tv_atom_sfb = tiled_atom_sfb.compose(AtomLayoutSFB_TV{}, _);
+
+    auto thr_layout_vmnk = mma.get_thr_layout_vmnk();
+    auto thr_tile        = make_tile(
+        _,
+        make_tile(
+            make_layout(size<2>(thr_layout_vmnk)),
+            make_layout(size<3>(thr_layout_vmnk))));
+    return zipped_divide(tv_atom_sfb, thr_tile);
+  }
+
+  // Returns a register fragment for SFB matching the per-thread MMA partition.
+  template <class SFBTensor, class ThrMma>
+  CUTE_HOST_DEVICE static constexpr auto
+  partition_fragment_SFB(SFBTensor&& sfbtensor, ThrMma& thread_mma) {
+    auto thr_tensor = make_tensor(
+        static_cast<SFBTensor&&>(sfbtensor).data(),
+        thrfrg_SFB(sfbtensor.layout(), thread_mma));
+    auto thr_vmnk = thread_mma.thr_vmnk_;
+    // SFB is indexed by ThrN (get<2>) and ThrK (get<3>), not ThrM (get<1>).
+    auto thr_vnk = make_coord(
+        get<0>(thr_vmnk),
+        make_coord(get<2>(thr_vmnk), get<3>(thr_vmnk)));
+    auto partition_SFB =
+        thr_tensor(thr_vnk, make_coord(_, repeat<rank<1, 1>(thr_tensor)>(_)));
+    return make_fragment_like<ElementSFLoad>(partition_SFB);
+  }
+
+  // Returns the SFB thread<->value layout for use with make_tiled_copy_impl.
+  template <class TiledMmaType>
+  CUTE_HOST_DEVICE static constexpr auto
+  get_layoutSFB_TV(TiledMmaType& mma) {
+    auto tile_shape_mnk  = tile_shape(mma);
+    auto ref_B           = make_layout(make_shape(size<1>(tile_shape_mnk), _1{}));
+    auto thr_tensor      = thrfrg_SFB(ref_B, mma);
+    auto thr_layout_vmnk = mma.get_thr_layout_vmnk();
+    // SFB strides: N-direction is collapsed (Int<0>{}), K-direction contributes (Int<1>{}).
+    auto btile = make_tile(
+        _,
+        make_tile(
+            make_layout(
+                make_shape(size<1>(thr_layout_vmnk), size<2>(thr_layout_vmnk)),
+                make_stride(Int<0>{}, Int<1>{})),
+            _));
+    auto tv_sfb         = thr_tensor.compose(btile, _);
+    auto thridx_2_thrid = right_inverse(thr_layout_vmnk);
+    return tv_sfb.compose(thridx_2_thrid, _);
+  }
+
+  // Reinterprets an int32 SF fragment as float_ue8m0_t for Blackwell RTX QMMA consumption.
+  // Output layout: (32:0, num_mn:4, 4:0, 4:1) matches Blackwell RTX QMMA scale operand format.
+  template <class Tensor>
+  CUTE_HOST_DEVICE static constexpr auto
+  transform_fragment_for_qmma(Tensor&& tensor) {
+    CUTE_STATIC_ASSERT_V(rank(tensor) == Int<3>{});
+    auto old_ptr = tensor.data();
+    auto new_ptr = recast_ptr<ElementSFCompute>(old_ptr);
+    auto num_mn  = size<1>(shape(tensor.layout()));
+    CUTE_STATIC_ASSERT_V(size<2>(shape(tensor.layout())) == Int<1>{});
+    auto new_layout = make_layout(
+        make_shape(_32{}, num_mn, _4{}, _4{}),
+        make_stride(_0{}, _4{}, _0{}, _1{}));
+    return make_tensor(new_ptr, new_layout);
+  }
+};
+
+} // namespace hstu

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/block_info.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/block_info.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, Tri Dao.
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace flash {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename Kernel_traits, typename Params>
+struct HstuBlockInfo {
+  __device__ HstuBlockInfo(const Params& params, const int bidb)
+      : sum_s_q(params.cu_seqlens_q[bidb]),
+        sum_s_k(params.cu_seqlens_k[bidb]),
+        sum_s_page(Kernel_traits::Paged_KV ? params.page_offsets[bidb] : 0),
+        actual_seqlen_c(
+            Kernel_traits::Is_context ? params.num_contexts[bidb] : 0),
+        actual_seqlen_q(
+          params.seqused_q ? params.seqused_q[bidb] : params.cu_seqlens_q[bidb + 1] - sum_s_q),
+        actual_seqlen_k(
+          params.seqused_k ? params.seqused_k[bidb] : params.cu_seqlens_k[bidb + 1] - sum_s_k),
+        actual_seqlen_q_padded(
+          params.cu_seqlens_q[bidb + 1] - sum_s_q),
+        actual_seqlen_k_padded(
+          params.cu_seqlens_k[bidb + 1] - sum_s_k),
+        actual_seqlen_t(Kernel_traits::Is_target ? params.num_targets[bidb] : 0),
+        actual_page_num(
+            Kernel_traits::Paged_KV ? params.page_offsets[bidb + 1] - sum_s_page : 0),
+        last_page_seqlen(Kernel_traits::Paged_KV ? params.last_page_lens[bidb] : 0) {}
+
+  template <typename index_t>
+  __forceinline__ __device__ index_t q_offset(const index_t row_stride) const {
+    return uint32_t(sum_s_q) * row_stride;
+  }
+
+  template <typename index_t>
+  __forceinline__ __device__ index_t k_offset(const index_t row_stride) const {
+    return uint32_t(sum_s_k) * row_stride;
+  }
+
+  template <typename index_t>
+  __forceinline__ __device__ index_t kv_cache_offset(const index_t row_stride) const {
+    return uint32_t(sum_s_q) * row_stride + (actual_seqlen_q - actual_seqlen_t) * row_stride;
+  }
+
+  const int sum_s_q;
+  const int sum_s_k;
+  const int sum_s_page;
+
+  const int actual_seqlen_c;
+  const int actual_seqlen_q;
+  const int actual_seqlen_k;
+  const int actual_seqlen_q_padded;
+  const int actual_seqlen_k_padded;
+  const int actual_seqlen_t;
+  const int actual_page_num;
+  const int last_page_seqlen;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace flash

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Blackwell RTX HSTU forward parameters.
+// Extends Ampere params with FP8 quantization fields (matching Hopper layout
+// so the same Python-level quantization code can be reused).
+
+#pragma once
+
+#include <cuda.h>
+#include <cstdint>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Hstu_params {
+  using index_t = int64_t;
+  void* __restrict__ q_ptr;
+  void* __restrict__ k_ptr;
+  void* __restrict__ v_ptr;
+
+  index_t q_row_stride;
+  index_t k_row_stride;
+  index_t v_row_stride;
+  index_t q_head_stride;
+  index_t k_head_stride;
+  index_t v_head_stride;
+  int h, h_k, h_rab;
+  int h_h_k_ratio;
+
+  bool is_balance_fwd;
+  bool is_balance_bwd;
+  int arch;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Hstu_fwd_params : public Hstu_params {
+  void* __restrict__ o_ptr;
+  index_t o_row_stride;
+  index_t o_head_stride;
+
+  int* __restrict__ cu_seqlens_q;
+  int* __restrict__ cu_seqlens_k;
+  int* __restrict__ seqused_q;
+  int* __restrict__ seqused_k;
+
+  int* __restrict__ num_targets;
+  int* __restrict__ num_contexts;
+
+  void* __restrict__ func_ptr;
+  index_t func_ids_stride;
+  index_t func_head_stride;
+  int func_batch;
+  int n_func;
+
+  void* __restrict__ rab_ptr;
+  index_t rab_seqlen_qk_stride;
+  index_t rab_seqlen_q_stride;
+  index_t rab_seqlen_k_stride;
+
+  // Paged KV cache for Blackwell RTX FP8 forward.
+  void* __restrict__ kv_cache_ptr = nullptr;
+  index_t kv_cache_row_stride = 0;
+  index_t kv_cache_head_stride = 0;
+  index_t kv_cache_page_stride = 0;
+  index_t kv_cache_kvtensor_stride = 0;
+  int page_size = 0;
+  int total_pages = 0;
+  int*  __restrict__ page_offsets = nullptr;
+  int*  __restrict__ page_ids = nullptr;
+  int*  __restrict__ last_page_lens = nullptr;
+
+  int b, seqlen_q, seqlen_k, d, seqlen_q_rounded, seqlen_k_rounded;
+  int scaling_seqlen;
+  float alpha;
+  int target_group_size;
+
+  int window_size_left;
+  int window_size_right;
+
+  bool has_rab;
+  bool is_bf16;
+  bool is_causal;
+  bool is_local;
+  bool is_target;
+  bool is_context;
+  bool is_paged_kv = false;
+  bool is_arbitrary_mask;
+
+  // FP8 quantization fields (quant_mode >= 0 means FP8)
+  // quant_mode: -1=BF16/FP16, 0=per-tensor FP8, 1-5=other FP8 modes
+  int quant_mode = -1;
+  int output_dtype = 0;  // 0=BF16, 1=FP16
+
+  // Per-tensor descale scalars (float*)
+  float* descale_q_ptr = nullptr;
+  float* descale_k_ptr = nullptr;
+  float* descale_v_ptr = nullptr;
+  float* descale_vt_ptr = nullptr;
+
+  index_t descale_q_head_stride = 0;
+  index_t descale_k_head_stride = 0;
+  index_t descale_v_head_stride = 0;
+  index_t descale_vt_head_stride = 0;
+  index_t descale_vt_row_stride = 0;
+
+  // Block-wise descale (quant_mode 2+); not used for quant_mode=0
+  int* cu_seqlens_vt_descale = nullptr;
+  int* cu_seqlens_q_block_descale = nullptr;
+  int* cu_seqlens_kv_block_descale = nullptr;
+  int* cu_seqlens_v_block_descale = nullptr;  // separate from K (V has different block granularity)
+  index_t q_block_descale_head_stride = 0;
+  index_t kv_block_descale_head_stride = 0;
+  index_t v_block_descale_head_stride = 0;   // stride for sf_v_packed (= descale_v.stride(0))
+  // Optional pre-packed e8m0x4 scales for blockwise FP8 (quant_mode=2).
+  // Layout is [head, total_blocks], each int32 packs 4 identical e8m0 bytes.
+  int32_t* sf_q_packed_ptr = nullptr;
+  int32_t* sf_k_packed_ptr = nullptr;
+  int32_t* sf_v_packed_ptr = nullptr;
+
+  // V-transposed pointer for quant_mode=1
+  void* __restrict__ vt_ptr = nullptr;
+  index_t vt_row_stride = 0;
+  index_t vt_head_stride = 0;
+
+  bool is_e4m3 = false;
+  bool is_e5m2 = false;
+
+  // Semaphore for dynamic tile scheduling (optional)
+  int* __restrict__ tile_count_semaphore = nullptr;
+  int num_sm = 0;
+  int total_q = 0;
+  int total_k = 0;
+
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Forward declaration (defined in generated .cu instantiation files compiled
+// in global namespace; matching the Hopper pattern in hstu_hopper/hstu.h).
+template <int Arch, typename T, int Headdim, bool Has_rab, bool Is_local,
+          bool Is_causal, bool Is_context, bool Is_target, bool Is_arbitrary, int kNFunc>
+void run_hstu_fwd_(Hstu_fwd_params& params, cudaStream_t stream);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_fwd_kernel_fp8_ws.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_fwd_kernel_fp8_ws.h
@@ -1,0 +1,2362 @@
+// Phase 6 warp-specialized FP8 kernel body — Q, K, and V^T via TMA.
+// Included inside namespace flash from hstu_fwd_kernel.h.
+// Do not include directly; use hstu_fwd_kernel.h.
+//
+// Warp layout (12 warps = 3 complete warpgroups, kNThreads=384):
+//   WG0: warps 0-3  (math)
+//   WG1: warps 4-7  (math)
+//   WG2: warps 8-11 (load warpgroup)
+//     warp 8  = Q/SFA TMA load
+//     warp 9  = K/SFB TMA load
+//     warp 10 = V/SFV TMA load
+//     warp 11 = O TMA store
+// Complete WG2 ensures setmaxnreg TRY_ALLOC WARPSYNC.ALL retry loop works correctly.
+// With __launch_bounds__(384,1): compiler budget = 65536/384 ≈ 168 regs → TRY_ALLOC(inc) succeeds
+// on first attempt (already at budget), no retry needed.
+//
+// CTA-level __syncthreads__ map (must match between branches):
+//   S_arb : Is_arbitrary only — math warp 1 writes sValidBlockIds; load warp just syncs
+//   S1    : after load warp inits producer/consumer mbarriers + fence; persistent full/causal does this
+//           once before the static scheduler loop, non-persistent paths keep the per-tile S1
+//   S2→   : replaced by wait_mbar_parity(q_ready_mbar_ptr, parity) for all 256 math threads
+//   S3    : removed (was a no-op rendezvous with no real data dependency)
+//   S5    : partial-tile-only math bar.sync; full O-store handoff uses o_ready/o_empty.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+__device__ __forceinline__ uint32_t mbar_smem_addr(uint64_t* mbar) {
+  return static_cast<uint32_t>(__cvta_generic_to_shared(mbar));
+}
+
+__device__ __forceinline__ void arrive_mbar(uint32_t maddr) {
+  asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];\n" : : "r"(maddr));
+}
+
+__device__ __forceinline__ void arrive_mbar(uint64_t* mbar) {
+  arrive_mbar(mbar_smem_addr(mbar));
+}
+
+__device__ __forceinline__ void arrive_expect_tx_mbar(
+    uint32_t maddr,
+    uint32_t expected_tx_bytes) {
+  asm volatile("mbarrier.arrive.expect_tx.shared::cta.b64 _, [%0], %1;\n"
+               : : "r"(maddr), "r"(expected_tx_bytes));
+}
+
+__device__ __forceinline__ void arrive_expect_tx_mbar(
+    uint64_t* mbar,
+    uint32_t expected_tx_bytes) {
+  arrive_expect_tx_mbar(mbar_smem_addr(mbar), expected_tx_bytes);
+}
+
+// Fast path with one non-suspending probe; long waits then use try_wait so the
+// warp can yield while TMA or another producer completes the phase.
+__device__ inline void wait_mbar_parity(uint32_t maddr, uint32_t parity) {
+  uint32_t done = 0;
+  asm volatile(
+      "{.reg .pred p;\n"
+      "mbarrier.test_wait.parity.shared::cta.b64 p, [%1], %2;\n"
+      "selp.u32 %0, 1, 0, p;}\n"
+      : "=r"(done) : "r"(maddr), "r"(parity) : "memory");
+  if (done) return;
+
+  constexpr uint32_t kTryWaitSuspendHint = 0x989680u;
+  do {
+    asm volatile(
+        "{.reg .pred p;\n"
+        "mbarrier.try_wait.parity.shared::cta.b64 p, [%1], %2, %3;\n"
+        "selp.u32 %0, 1, 0, p;}\n"
+        : "=r"(done) : "r"(maddr), "r"(parity), "r"(kTryWaitSuspendHint) : "memory");
+  } while (!done);
+}
+
+__device__ inline void wait_mbar_parity(uint64_t* mbar, uint32_t parity) {
+  wait_mbar_parity(mbar_smem_addr(mbar), parity);
+}
+
+struct HstuWsTileCoord {
+  int bidb;
+  int bidh;
+  int m_block;
+};
+
+__device__ __forceinline__ HstuWsTileCoord hstu_ws_decode_tile(
+    const int tile,
+    const int num_m_block,
+    const int num_heads,
+    const bool head_shared_rab) {
+  if (head_shared_rab) {
+    const int bidh = tile % num_heads;
+    const int bm = tile / num_heads;
+    const int m_linear = bm % num_m_block;
+    return HstuWsTileCoord{
+        bm / num_m_block,
+        bidh,
+        num_m_block - 1 - m_linear};
+  } else {
+    const int m_linear = tile % num_m_block;
+    const int bh = tile / num_m_block;
+    return HstuWsTileCoord{
+        bh / num_heads,
+        bh % num_heads,
+        num_m_block - 1 - m_linear};
+  }
+}
+
+// Pack GEMM1 C-fragment (acc_s) to FP8 and rearrange it to GEMM2 A-fragment
+// (tCrP) layout using warp shuffle only.  BN64 and BN128 use different
+// C-fragment N atom order.
+//
+// With AtomLayout <_8,_1,_1> (1 N-warp), each warp holds all 128 N-values of P in its
+// own registers after GEMM1. No cross-warp communication is needed: the entire D→A
+// rearrangement is intra-warp, performed by SHFL.IDX within each 4-thread quad.
+//
+// QMMA.SF.16832 coordinate mappings (SPA ISA):
+//   C-fragment: packed N-atom nr has bytes {mr=0,i=0},{mr=0,i=1},{mr=1,i=0},{mr=1,i=1}
+//     where N_base(nr) = (nr%4)*32 + (nr/4)*8  (from PermMmaTileN strides (1,32,8))
+//     and   col = N_base(nr) + (lane&3)*2 + i
+//   A-fragment: tCrP[4*kb + 2*c + mr] at row=8*mr+(lane>>2), col=32*kb+16*c+(lane&3)*4+{0..3}
+//
+// For each (kb,c), the 4 K-values needed by one thread span two consecutive C-fragment
+// atoms: atom_lo covers col[0..1] (from src_lane0) and atom_hi covers col[2..3] (from src_lane1).
+//   src_lane0 = (lane & ~3u) | ((lane&1u) << 1)  — lower pair of the quad
+//   src_lane1 = src_lane0 + 1                     — upper pair of the quad
+// kAtomLut[kb][c][h]: C-fragment atom index for K-half h (h = (lane&3)>>1).
+//   kAtomLut[kb][c][h] = kb + 4*(2*c + h)
+// Byte assembly:
+//   mr=0 (row=quad):   __byte_perm(a, b, 0x5410) = {a.b0,a.b1,b.b0,b.b1}
+//   mr=1 (row=8+quad): __byte_perm(a, b, 0x7632) = {a.b2,a.b3,b.b2,b.b3}
+//
+// Cost for BN128: 16 FP8 pair converts + 32 SHFL + 16 BYTE_PERM per thread.
+// Savings: eliminates 2 × bar.sync (256-thread) + 16KB SMEM write + LDSM load-back.
+template <int kBlockN, int kHeadDim, typename PFragment, typename AccFragment>
+__device__ __forceinline__ void permute_acc_s_packed_to_tCrP(
+    PFragment& tCrP,
+    AccFragment const& acc_s,
+    int tidx_math) {
+  static_assert(kBlockN == 64 || kBlockN == 128, "GEMM2 P permutation supports BN64/BN128");
+  constexpr int kPackedElems = kBlockN / 8;
+  constexpr int kAccSElems = 4 * kPackedElems;
+  uint32_t acc_s_packed[kPackedElems];
+
+  CUTE_UNROLL
+  for (int flat = 0; flat < kAccSElems; flat += 4) {
+    uint32_t out;
+    asm volatile(
+        "{\n"
+        ".reg .b16 lo, hi;\n"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, %2, %1;\n"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, %4, %3;\n"
+        "mov.b32 %0, {lo, hi};\n"
+        "}\n"
+        : "=r"(out)
+        : "f"(static_cast<float>(acc_s(flat + 0))),
+          "f"(static_cast<float>(acc_s(flat + 1))),
+          "f"(static_cast<float>(acc_s(flat + 2))),
+          "f"(static_cast<float>(acc_s(flat + 3))));
+    acc_s_packed[flat / 4] = out;
+  }
+
+  auto tXrP = recast<uint32_t>(tCrP);
+  const unsigned lane      = (unsigned)tidx_math & 31u;
+  const unsigned tiq       = lane & 3u;
+  const unsigned quad_base = lane & ~3u;
+  const unsigned src_lane0 = quad_base | ((tiq & 1u) << 1u);
+  const unsigned src_lane1 = src_lane0 + 1u;
+
+  if constexpr (kBlockN == 64) {
+    CUTE_UNROLL
+    for (int kb = 0; kb < 2; ++kb) {
+      CUTE_UNROLL
+      for (int c = 0; c < 2; ++c) {
+        const uint32_t pk0 = acc_s_packed[4 * kb + 2 * c + 0];
+        const uint32_t pk1 = acc_s_packed[4 * kb + 2 * c + 1];
+        const uint32_t a0  = __shfl_sync(0xFFFFFFFFu, pk0, src_lane0);
+        const uint32_t b0  = __shfl_sync(0xFFFFFFFFu, pk0, src_lane1);
+        const uint32_t a1  = __shfl_sync(0xFFFFFFFFu, pk1, src_lane0);
+        const uint32_t b1  = __shfl_sync(0xFFFFFFFFu, pk1, src_lane1);
+        const uint32_t a   = (tiq >> 1u) ? a1 : a0;
+        const uint32_t b   = (tiq >> 1u) ? b1 : b0;
+        tXrP(4 * kb + 2 * c + 0) = __byte_perm(a, b, 0x5410u);
+        tXrP(4 * kb + 2 * c + 1) = __byte_perm(a, b, 0x7632u);
+      }
+    }
+    if constexpr (kHeadDim == 256) {
+      CUTE_UNROLL
+      for (int i = 8; i < size(tXrP); ++i) {
+        tXrP(i) = tXrP(i & 7);
+      }
+    }
+  } else {
+    constexpr uint8_t kLut0[4][2] = {{ 0, 8}, { 1, 9}, { 2, 10}, { 3, 11}};
+    constexpr uint8_t kLut1[4][2] = {{ 4,12}, { 5,13}, { 6, 14}, { 7, 15}};
+    CUTE_UNROLL
+    for (int kb = 0; kb < 4; ++kb) {
+      CUTE_UNROLL
+      for (int c = 0; c < 2; ++c) {
+        const uint32_t pk0 = acc_s_packed[kLut0[kb][c]];
+        const uint32_t pk1 = acc_s_packed[kLut1[kb][c]];
+        const uint32_t a0  = __shfl_sync(0xFFFFFFFFu, pk0, src_lane0);
+        const uint32_t b0  = __shfl_sync(0xFFFFFFFFu, pk0, src_lane1);
+        const uint32_t a1  = __shfl_sync(0xFFFFFFFFu, pk1, src_lane0);
+        const uint32_t b1  = __shfl_sync(0xFFFFFFFFu, pk1, src_lane1);
+        const uint32_t a   = (tiq >> 1u) ? a1 : a0;
+        const uint32_t b   = (tiq >> 1u) ? b1 : b0;
+        tXrP(4 * kb + 2 * c + 0) = __byte_perm(a, b, 0x5410u);
+        tXrP(4 * kb + 2 * c + 1) = __byte_perm(a, b, 0x7632u);
+      }
+    }
+  }
+}
+
+template <
+    typename Kernel_traits,
+    int kBlockN,
+    int kHeadDim,
+    int kHeadDimGemm2,
+    typename FP8Elem,
+    typename Fragment>
+__device__ __forceinline__ void hstu_ws_load_v_ldsm_t(
+    FP8Elem* sVt_cur,
+    Fragment& tCrV,
+    int tidx_math) {
+  auto tXrV = recast<uint32_t>(tCrV);
+  if constexpr (kHeadDim < kHeadDimGemm2) {
+    clear(tCrV);
+  }
+  const uint32_t v_smem_base = static_cast<uint32_t>(__cvta_generic_to_shared(sVt_cur));
+  typename Kernel_traits::SmemLayoutVt_TMA smem_layout_vt;
+  const int lane = tidx_math & 31;
+  const int n_off = lane & 15;
+  const int d_mat = (lane >> 4) << 4;
+
+  CUTE_UNROLL
+  for (int dg = 0; dg < kHeadDim / 32; ++dg) {
+    CUTE_UNROLL
+    for (int ni = 0; ni < kBlockN / 16; ++ni) {
+      const int n_k_row = ni * 16 + n_off;
+      const int d_start = dg * 32 + d_mat;
+      const uint32_t addr_slab =
+          v_smem_base + (uint32_t)smem_layout_vt(n_k_row, d_start);
+
+      if constexpr (kHeadDim <= 64) {
+        const int base = 16 * (ni >> 1) + 8 * dg + (ni & 1);
+        asm volatile(
+            "ldmatrix.sync.aligned.m16n16.x2.trans.shared.b8 {%0,%1,%2,%3},[%4];\n"
+            : "=r"(tXrV(base + 0)), "=r"(tXrV(base + 2)),
+              "=r"(tXrV(base + 4)), "=r"(tXrV(base + 6))
+            : "r"(addr_slab));
+      } else {
+        const int dg_slab = dg >> 2;
+        const int dg_in_slab = dg & 3;
+        const int base =
+            (kHeadDim / 4) * (ni >> 1) + 32 * dg_slab + 2 * dg_in_slab + (ni & 1);
+        asm volatile(
+            "ldmatrix.sync.aligned.m16n16.x2.trans.shared.b8 {%0,%1,%2,%3},[%4];\n"
+            : "=r"(tXrV(base + 0)), "=r"(tXrV(base + 8)),
+              "=r"(tXrV(base + 16)), "=r"(tXrV(base + 24))
+            : "r"(addr_slab));
+      }
+    }
+  }
+}
+
+__device__ __forceinline__ int32_t hstu_ws_replicate_e8m0_lane(
+    int32_t packed,
+    int lane) {
+  const uint32_t byte = (static_cast<uint32_t>(packed) >> (8 * lane)) & 0xffu;
+  return static_cast<int32_t>(byte | (byte << 8) | (byte << 16) | (byte << 24));
+}
+
+template <
+    typename Kernel_traits,
+    bool Target_group_size_1,
+    typename Params,
+    typename ThrMmaG1,
+    typename AccTensor,
+    typename MinFuncTensor,
+    typename MaxFuncTensor>
+__device__ __forceinline__ void hstu_ws_apply_mask_bs(
+    AccTensor& tSrS,
+    int nb,
+    const Params& params,
+    ThrMmaG1& thr_mma_g1,
+    MinFuncTensor& gMinFunc,
+    MaxFuncTensor& gMaxFunc,
+    int m_block,
+    int actual_seqlen_k,
+    int actual_seqlen_h,
+    int actual_seqlen_c,
+    int actual_seqlen_offset,
+    int last_page_offset) {
+  constexpr bool Is_causal    = Kernel_traits::Is_causal;
+  constexpr bool Is_target    = Kernel_traits::Is_target;
+  constexpr bool Is_context   = Kernel_traits::Is_context;
+  constexpr bool Is_arbitrary = Kernel_traits::Is_arbitrary;
+  constexpr bool Is_local     = Kernel_traits::Is_local;
+  constexpr bool Paged_KV     = Kernel_traits::Paged_KV;
+  constexpr int kBlockM       = Kernel_traits::kBlockM;
+  constexpr int kBlockN       = Kernel_traits::kBlockN;
+  static constexpr int Row = 0, Col = 1;
+
+  Tensor cS = make_identity_tensor(Shape<Int<kBlockM>, Int<kBlockN>>{});
+  Tensor tScS = thr_mma_g1.partition_C(cS);
+  const int base_row = m_block * kBlockM + actual_seqlen_offset;
+  const int base_col = nb * kBlockN;
+  Tensor col_min = make_tensor<int>(make_shape(size<0>(gMinFunc)));
+  Tensor col_max = make_tensor<int>(make_shape(size<0>(gMaxFunc)));
+  int prev_block_row = -1;
+  int row = 0;
+  [[maybe_unused]] int tgt_col_lft = 0;
+
+#pragma unroll
+  for (int flat = 0; flat < size(tSrS); ++flat) {
+    const auto coord = tScS(flat);
+    const int block_row = int(get<Row>(coord));
+    if (block_row != prev_block_row) {
+      row = block_row + base_row;
+      prev_block_row = block_row;
+      if constexpr (Is_target) {
+        if constexpr (Target_group_size_1) {
+          tgt_col_lft = row;
+        } else {
+          const int tgt_idx = (row - actual_seqlen_h) / params.target_group_size;
+          tgt_col_lft = actual_seqlen_h + tgt_idx * params.target_group_size;
+        }
+      }
+      if constexpr (Is_arbitrary) {
+        col_max(0) = gMaxFunc(0, block_row);
+#pragma unroll
+        for (int j = 0; j < size<0>(gMinFunc); ++j) {
+          col_min(j) = gMinFunc(j, block_row);
+          col_max(j + 1) = gMaxFunc(j + 1, block_row);
+        }
+      }
+    }
+
+    const int block_col = int(get<Col>(coord));
+    int col = block_col + base_col;
+    if (Paged_KV && row >= actual_seqlen_h) {
+      col -= last_page_offset;
+    }
+    if constexpr (!Is_causal && !Is_local && !Is_arbitrary) {
+      if (col >= actual_seqlen_k) {
+        tSrS(flat) = -INFINITY;
+        continue;
+      }
+    } else {
+      if constexpr (Is_context) {
+        if (row < actual_seqlen_c && col < actual_seqlen_h) continue;
+      }
+      if (col >= std::min(actual_seqlen_k, row + 1 + params.window_size_right)) {
+        tSrS(flat) = -INFINITY;
+        continue;
+      }
+      if constexpr (Is_local) {
+        if (col < std::max(0, row - params.window_size_left)) {
+          tSrS(flat) = -INFINITY;
+          continue;
+        }
+      }
+      if constexpr (Is_target) {
+        if (row >= actual_seqlen_h &&
+            (col + (Paged_KV ? last_page_offset : 0)) >= actual_seqlen_h &&
+            col < tgt_col_lft) {
+          tSrS(flat) = -INFINITY;
+        }
+      }
+      if constexpr (Is_arbitrary) {
+        bool non_mask = (0 <= col) && (col < col_max(0));
+        if (non_mask) continue;
+#pragma unroll
+        for (int j = 0; j < size<0>(gMinFunc); ++j) {
+          non_mask = (col_min(j) <= col) && (col < col_max(j + 1));
+          if (non_mask) break;
+        }
+        if (!non_mask) tSrS(flat) = -INFINITY;
+      }
+    }
+  }
+}
+
+template <
+    typename Kernel_traits,
+    typename AccTensor,
+    typename ThrMmaG1,
+    typename RabTensor>
+__device__ __forceinline__ void hstu_ws_add_rab_smem_bs(
+    AccTensor& tSrS,
+    int nb,
+    bool skip_masked,
+    int stage,
+    ThrMmaG1& thr_mma_g1,
+    RabTensor& sRab,
+    int m_block,
+    int actual_seqlen_q,
+    int actual_seqlen_k,
+    int actual_seqlen_h,
+    int n_block_paged,
+    int last_page_offset) {
+  if constexpr (Kernel_traits::Has_rab) {
+    constexpr bool Is_target = Kernel_traits::Is_target;
+    constexpr bool Paged_KV  = Kernel_traits::Paged_KV;
+    constexpr int kBlockM    = Kernel_traits::kBlockM;
+    constexpr int kBlockN    = Kernel_traits::kBlockN;
+    static constexpr int Row = 0, Col = 1;
+
+    Tensor cS = make_identity_tensor(Shape<Int<kBlockM>, Int<kBlockN>>{});
+    Tensor tScS = thr_mma_g1.partition_C(cS);
+    const int base_col = nb * kBlockN;
+
+    CUTE_UNROLL
+    for (int flat = 0; flat < size(tSrS); ++flat) {
+      if (skip_masked && tSrS(flat) == -INFINITY) {
+        continue;
+      }
+      const auto coord = tScS(flat);
+      const int block_row = int(get<Row>(coord));
+      const int q_idx = m_block * kBlockM + block_row;
+      if (q_idx >= actual_seqlen_q) {
+        continue;
+      }
+      const int block_col = int(get<Col>(coord));
+      int col = block_col + base_col;
+      if constexpr (Paged_KV && Is_target) {
+        if (nb >= n_block_paged) {
+          col -= last_page_offset;
+        }
+        if (nb < n_block_paged && col >= actual_seqlen_h) {
+          continue;
+        }
+      }
+      if (0 <= col && col < actual_seqlen_k) {
+        tSrS(flat) += static_cast<float>(sRab(block_row, block_col, stage));
+      }
+    }
+  }
+}
+
+template <
+    typename Kernel_traits,
+    typename AccTensor,
+    typename ThrMmaG1,
+    typename RabTensor>
+__device__ __forceinline__ void hstu_ws_consume_rab_bs(
+    AccTensor& tSrS,
+    int nb,
+    bool skip_masked,
+    int& rab_ready_wait_parity0,
+    uint32_t smem_base32,
+    int tidx_math,
+    ThrMmaG1& thr_mma_g1,
+    RabTensor& sRab,
+    int m_block,
+    int actual_seqlen_q,
+    int actual_seqlen_k,
+    int actual_seqlen_h,
+    int n_block_paged,
+  int last_page_offset) {
+  if constexpr (Kernel_traits::Has_rab) {
+    static constexpr int kSmemMbar0Offset =
+        Kernel_traits::kSmemSize - Kernel_traits::kSmemMbarSize;
+    wait_mbar_parity(
+        smem_base32 + (uint32_t)kSmemMbar0Offset + 112u,
+        (uint32_t)rab_ready_wait_parity0);
+    rab_ready_wait_parity0 ^= 1;
+    asm volatile("" ::: "memory");
+    hstu_ws_add_rab_smem_bs<Kernel_traits>(
+        tSrS,
+        nb,
+        skip_masked,
+        0,
+        thr_mma_g1,
+        sRab,
+        m_block,
+        actual_seqlen_q,
+        actual_seqlen_k,
+        actual_seqlen_h,
+        n_block_paged,
+        last_page_offset);
+    if ((tidx_math & 31) == 0) {
+      arrive_mbar(smem_base32 + (uint32_t)kSmemMbar0Offset + 120u);
+    }
+  }
+}
+
+template <
+    typename Kernel_traits,
+    typename AccTensor,
+    typename ThrMmaG1,
+    typename RabTensor>
+__device__ __forceinline__ void hstu_ws_add_rab_smem_paged_target_bs(
+    AccTensor& tSrS,
+    ThrMmaG1& thr_mma_g1,
+    RabTensor& sRab) {
+  if constexpr (Kernel_traits::Has_rab) {
+    static_assert(Kernel_traits::Paged_KV && Kernel_traits::Is_target);
+    constexpr int kBlockM = Kernel_traits::kBlockM;
+    constexpr int kBlockN = Kernel_traits::kBlockN;
+    static constexpr int Row = 0, Col = 1;
+
+    Tensor cS = make_identity_tensor(Shape<Int<kBlockM>, Int<kBlockN>>{});
+    Tensor tScS = thr_mma_g1.partition_C(cS);
+
+    CUTE_UNROLL
+    for (int flat = 0; flat < size(tSrS); ++flat) {
+      const auto coord = tScS(flat);
+      const int block_row = int(get<Row>(coord));
+      const int block_col = int(get<Col>(coord));
+      tSrS(flat) += static_cast<float>(sRab(block_row, block_col, _0{}));
+    }
+  }
+}
+
+template <
+    typename Kernel_traits,
+    typename AccTensor,
+    typename ThrMmaG1,
+    typename RabTensor>
+__device__ __forceinline__ void hstu_ws_consume_rab_paged_target_bs(
+    AccTensor& tSrS,
+    int& rab_ready_wait_parity0,
+    uint32_t smem_base32,
+    int tidx_math,
+    ThrMmaG1& thr_mma_g1,
+    RabTensor& sRab) {
+  if constexpr (Kernel_traits::Has_rab) {
+    static_assert(Kernel_traits::Paged_KV && Kernel_traits::Is_target);
+    static constexpr int kSmemMbar0Offset =
+        Kernel_traits::kSmemSize - Kernel_traits::kSmemMbarSize;
+    wait_mbar_parity(
+        smem_base32 + (uint32_t)kSmemMbar0Offset + 112u,
+        (uint32_t)rab_ready_wait_parity0);
+    rab_ready_wait_parity0 ^= 1;
+    asm volatile("" ::: "memory");
+    hstu_ws_add_rab_smem_paged_target_bs<Kernel_traits>(
+        tSrS, thr_mma_g1, sRab);
+    if ((tidx_math & 31) == 0) {
+      arrive_mbar(smem_base32 + (uint32_t)kSmemMbar0Offset + 120u);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename Kernel_traits,
+    bool Use_full_persistent = false,
+    bool Use_paired_persistent = false,
+    bool Target_group_size_1 = false,
+    typename Params>
+inline __device__ void hstu_compute_attn_1rowblock_blackwell_rtx_fp8_ws(
+    const Params& params,
+    const int bidb_arg,
+    const int bidh_arg,
+    int m_block_arg) {
+
+  static_assert(Kernel_traits::Is_fp8, "Phase 6 WS: FP8 path only");
+  static_assert(
+      !(Use_full_persistent && Use_paired_persistent),
+      "Only one FP8 WS persistent scheduler can be enabled");
+  constexpr bool Use_persistent = Use_full_persistent || Use_paired_persistent;
+
+  using BS1 = hstu::BlackwellRtxQmmaBuilder<
+      Kernel_traits::kBlockM, Kernel_traits::kBlockN, 4>;
+  static constexpr int kHeadDimGemm2 =
+      Kernel_traits::kHeadDim < 64 ? 64 : Kernel_traits::kHeadDim;
+  using BS2 = hstu::BlackwellRtxQmmaBuilder<
+      Kernel_traits::kBlockM, kHeadDimGemm2, 4>;
+  using FP8Elem = typename Kernel_traits::Element;
+
+  extern __shared__ char smem_[];
+  static constexpr int kSmemMbar0Offset =
+      Kernel_traits::kSmemSize - Kernel_traits::kSmemMbarSize;
+
+  const int tidx = threadIdx.x;
+  constexpr int kNMathThreads = Kernel_traits::kNMathThreads;  // 256
+  const bool is_load_store_warp = (tidx >= kNMathThreads);
+
+  constexpr int kBlockM = Kernel_traits::kBlockM;
+  const int num_m_block_capacity = (params.seqlen_q + kBlockM - 1) / kBlockM;
+  int num_m_block_scheduler = num_m_block_capacity;
+  constexpr bool Use_actual_target_scheduler =
+      Use_persistent &&
+      Kernel_traits::Is_target &&
+      !Kernel_traits::Paged_KV &&
+      !Kernel_traits::Has_rab;
+  const int uniform_actual_seqlen_q =
+      (params.b > 0 && params.total_q % params.b == 0)
+      ? params.total_q / params.b
+      : 0;
+  if constexpr (Use_actual_target_scheduler) {
+    if (uniform_actual_seqlen_q > 0 &&
+        uniform_actual_seqlen_q < params.seqlen_q) {
+      num_m_block_scheduler =
+          (uniform_actual_seqlen_q + kBlockM - 1) / kBlockM;
+    }
+    const int total_tiles_scheduler =
+        num_m_block_scheduler * params.h * params.b;
+    int work_units_scheduler = total_tiles_scheduler;
+    if constexpr (Use_paired_persistent) {
+      work_units_scheduler =
+          ((num_m_block_scheduler + 1) / 2) * params.h * params.b;
+    }
+    if (int(blockIdx.x) >= work_units_scheduler) return;
+  }
+
+  // CTA-level sync before setmaxnreg: all warps start from clean state.
+  __syncthreads();
+
+  // ============================================================
+  // LOAD WARPGROUP PATH  (warps 8-11, threads 256-383)
+  //   warp 8  (tidx 256-287): Q/SFA load
+  //   warp 9  (tidx 288-319): K/SFB load
+  //   warp 10 (tidx 320-351): V/SFV load
+  //   warp 11 (tidx 352-383): O store
+  // ============================================================
+  if (is_load_store_warp) {
+    // Four load warps are role-specialized:
+    //   warp 8  : Q + SFA TMA load
+    //   warp 9  : K + SFB TMA load
+    //   warp 10 : V + SFV TMA load
+    //   warp 11 : O TMA store
+    const int load_warp_id = (tidx - kNMathThreads) >> 5;
+    const bool is_q_load_warp = load_warp_id == 0;
+    const bool is_k_load_warp = load_warp_id == 1;
+    const bool is_v_load_warp = load_warp_id == 2;
+
+    if constexpr (
+        Kernel_traits::kHeadDim > 128 &&
+        Kernel_traits::Paged_KV &&
+        Kernel_traits::Has_rab) {
+      if (is_k_load_warp || is_v_load_warp) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;" : : "n"(56));
+      } else {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;" : : "n"(40));
+      }
+    } else if constexpr (Kernel_traits::kHeadDim > 128) {
+      asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;" : : "n"(40));
+    } else {
+      asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;" : : "n"(56));
+    }
+
+    constexpr bool Is_causal    = Kernel_traits::Is_causal;
+    constexpr bool Is_target    = Kernel_traits::Is_target;
+    constexpr bool Is_context   = Kernel_traits::Is_context;
+    constexpr bool Is_arbitrary = Kernel_traits::Is_arbitrary;
+    constexpr int  kNFunc       = Kernel_traits::kNFunc;
+    constexpr bool Is_local     = Kernel_traits::Is_local;
+    constexpr bool Has_rab      = Kernel_traits::Has_rab;
+    constexpr bool Use_rab_smem = Kernel_traits::kUseRabSmem;
+    constexpr bool Paged_KV     = Kernel_traits::Paged_KV;
+    constexpr int  kBlockM      = Kernel_traits::kBlockM;
+    constexpr int  kBlockN      = Kernel_traits::kBlockN;
+    constexpr int  kHeadDim     = Kernel_traits::kHeadDim;
+    using OutElement = typename Kernel_traits::OutputType;
+
+    uint64_t* k_ready_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset);
+    uint64_t* k_ready_mbar_ptr1 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 8);
+    uint64_t* v_ready_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 16);
+    uint64_t* v_ready_mbar_ptr1 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 24);
+    uint64_t* k_empty_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 32);
+    uint64_t* k_empty_mbar_ptr1 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 40);
+    uint64_t* v_empty_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 48);
+    uint64_t* v_empty_mbar_ptr1 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 56);
+    uint64_t* q_ready_mbar_ptr  = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 64);
+    uint64_t* q_empty_mbar_ptr  = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 72);
+    uint64_t* o_ready_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 80);
+    uint64_t* o_ready_mbar_ptr1 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 88);
+    uint64_t* o_empty_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 96);
+    uint64_t* o_empty_mbar_ptr1 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 104);
+    uint64_t* rab_ready_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 112);
+    uint64_t* rab_empty_mbar_ptr0 = reinterpret_cast<uint64_t*>(smem_ + kSmemMbar0Offset + 120);
+
+    auto init_ws_mbarriers = [&]() {
+      if (tidx == kNMathThreads) {
+        uint32_t kr0 = static_cast<uint32_t>(__cvta_generic_to_shared(k_ready_mbar_ptr0));
+        uint32_t kr1 = static_cast<uint32_t>(__cvta_generic_to_shared(k_ready_mbar_ptr1));
+        uint32_t vr0 = static_cast<uint32_t>(__cvta_generic_to_shared(v_ready_mbar_ptr0));
+        uint32_t vr1 = static_cast<uint32_t>(__cvta_generic_to_shared(v_ready_mbar_ptr1));
+        uint32_t ke0 = static_cast<uint32_t>(__cvta_generic_to_shared(k_empty_mbar_ptr0));
+        uint32_t ke1 = static_cast<uint32_t>(__cvta_generic_to_shared(k_empty_mbar_ptr1));
+        uint32_t ve0 = static_cast<uint32_t>(__cvta_generic_to_shared(v_empty_mbar_ptr0));
+        uint32_t ve1 = static_cast<uint32_t>(__cvta_generic_to_shared(v_empty_mbar_ptr1));
+        uint32_t qr  = static_cast<uint32_t>(__cvta_generic_to_shared(q_ready_mbar_ptr));
+        uint32_t qe  = static_cast<uint32_t>(__cvta_generic_to_shared(q_empty_mbar_ptr));
+        uint32_t or0 = static_cast<uint32_t>(__cvta_generic_to_shared(o_ready_mbar_ptr0));
+        uint32_t or1 = static_cast<uint32_t>(__cvta_generic_to_shared(o_ready_mbar_ptr1));
+        uint32_t oe0 = static_cast<uint32_t>(__cvta_generic_to_shared(o_empty_mbar_ptr0));
+        uint32_t oe1 = static_cast<uint32_t>(__cvta_generic_to_shared(o_empty_mbar_ptr1));
+        uint32_t rr0 = static_cast<uint32_t>(__cvta_generic_to_shared(rab_ready_mbar_ptr0));
+        uint32_t re0 = static_cast<uint32_t>(__cvta_generic_to_shared(rab_empty_mbar_ptr0));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(kr0), "r"(1));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(kr1), "r"(1));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(vr0), "r"(1));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(vr1), "r"(1));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(ke0), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(ke1), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(ve0), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(ve1), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(qr), "r"(1));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(qe), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(or0), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(or1), "r"(8));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(oe0), "r"(1));
+        asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(oe1), "r"(1));
+        if constexpr (Use_rab_smem) {
+          asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(rr0), "r"(1));
+          asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" : : "r"(re0), "r"(8));
+        }
+        for (int i = 0; i < 8; i++) {
+          arrive_mbar(ke0);
+          arrive_mbar(ke1);
+          arrive_mbar(ve0);
+          arrive_mbar(ve1);
+          arrive_mbar(qe);
+          if constexpr (Use_rab_smem) {
+            arrive_mbar(re0);
+          }
+        }
+        // Independent O buffer starts empty; math epilogue waits on this phase before
+        // writing O, and the O-store warp releases the next phase after TMA store wait.
+        arrive_mbar(oe0);
+      }
+      asm volatile("fence.proxy.async.shared::cta;\n" : : : "memory");
+    };
+
+    int k_empty_wait_parity0 = 0;
+    int k_empty_wait_parity1 = 0;
+    int v_empty_wait_parity0 = 0;
+    int v_empty_wait_parity1 = 0;
+    int q_empty_wait_parity = 0;
+    int o_ready_wait_parity0 = 0;
+    int o_empty_load_wait_parity0 = 0;
+    int rab_empty_wait_parity0 = 0;
+    int kv_load_stage = 0;
+    if constexpr (Use_persistent) {
+      init_ws_mbarriers();
+      __syncthreads();  // One-time S1 for persistent: WS mbarriers initialized before scheduler loop.
+    }
+
+    auto run_load_store_tile = [&](auto load_role, const int bidb, const int bidh, int m_block) {
+      constexpr int LoadRole = decltype(load_role)::value;
+      constexpr bool IsQLoadRole = LoadRole == 0;
+      constexpr bool IsKLoadRole = LoadRole == 1;
+      constexpr bool IsVLoadRole = LoadRole == 2;
+      constexpr bool IsOStoreRole = LoadRole == 3;
+      const HstuBlockInfo<Kernel_traits, Params> binfo(params, bidb);
+      // Early exit 1: before any sync — both branches exit simultaneously.
+      if (m_block * kBlockM >= binfo.actual_seqlen_q_padded) return;
+
+      char* smem_q    = reinterpret_cast<char*>(smem_);
+      char* smem_func = reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsFuncOffset;
+      int* sn_valid_block_max = reinterpret_cast<int*>(smem_func);
+
+      const int actual_seqlen_q        = binfo.actual_seqlen_q;
+      const int actual_seqlen_k        = binfo.actual_seqlen_k;
+      const int actual_seqlen_t        = Is_target  ? binfo.actual_seqlen_t : 0;
+      const int actual_seqlen_c        = Is_context ? binfo.actual_seqlen_c : 0;
+      const int actual_seqlen_h        = Is_target  ? actual_seqlen_k - actual_seqlen_t : actual_seqlen_k;
+      const int actual_seqlen_offset   = actual_seqlen_k - actual_seqlen_q;
+      const int last_page_seqlen       = Paged_KV ? binfo.last_page_seqlen : kBlockN;
+      const int page_offset            = Paged_KV ? binfo.sum_s_page : 0;
+
+      const bool is_jump             = Is_target && m_block * kBlockM + actual_seqlen_offset > actual_seqlen_h;
+      const bool is_in_target        = Is_target && (m_block + 1) * kBlockM + actual_seqlen_offset > actual_seqlen_h;
+      const bool is_in_context       = Is_context && (m_block + 1) * kBlockM <= actual_seqlen_c;
+      const bool is_in_mixed_context = Is_context &&
+          (m_block + 1) * kBlockM > actual_seqlen_c && m_block * kBlockM < actual_seqlen_c;
+      const bool is_in_paged_target  = is_in_target && Paged_KV;
+      const int last_page_offset     = is_in_paged_target ? kBlockN - last_page_seqlen : 0;
+
+      const int n_block_history = cute::ceil_div(actual_seqlen_h, kBlockN);
+      const int n_block_paged   = Paged_KV ? n_block_history : 0;
+      const int n_block_target  = cute::ceil_div(actual_seqlen_t, kBlockN);
+
+      int n_block_min = !Is_local ? 0
+          : std::max(0, (m_block * kBlockM + actual_seqlen_offset - params.window_size_left) / kBlockN);
+      int n_block_max = Paged_KV ? n_block_history + n_block_target : cute::ceil_div(actual_seqlen_k, kBlockN);
+      if constexpr (Is_causal || Is_local) {
+        int offset = (m_block + 1) * kBlockM + actual_seqlen_offset + params.window_size_right;
+        if (is_in_paged_target) offset += last_page_offset;
+        n_block_max = std::min(n_block_max, cute::ceil_div(offset, kBlockN));
+      }
+      if constexpr (Is_context) {
+        n_block_min = (is_in_context || is_in_mixed_context) ? 0 : n_block_min;
+        n_block_max = (is_in_context || is_in_mixed_context)
+            ? std::max(n_block_history, n_block_max) : n_block_max;
+      }
+
+      int n_masking_block_max = cute::ceil_div(
+          std::min(actual_seqlen_k + last_page_offset,
+                   (m_block + 1) * kBlockM + actual_seqlen_offset + last_page_offset),
+          kBlockN);
+      int n_masking_block_min = (m_block * kBlockM + actual_seqlen_offset) / kBlockN;
+      if constexpr (Is_target) {
+        if constexpr (Target_group_size_1) {
+          n_masking_block_min = is_jump
+              ? (m_block * kBlockM + actual_seqlen_offset + last_page_offset) / kBlockN
+              : n_masking_block_min;
+        } else {
+          const int target_index =
+              (m_block * kBlockM - actual_seqlen_h) / params.target_group_size;
+          n_masking_block_min = is_jump
+              ? (actual_seqlen_h + actual_seqlen_offset +
+                 target_index * params.target_group_size + last_page_offset) / kBlockN
+              : n_masking_block_min;
+        }
+      }
+      if constexpr (Is_context) {
+        n_masking_block_min = is_in_mixed_context ? n_block_min : n_masking_block_min;
+        n_masking_block_max = is_in_mixed_context ? n_block_max : n_masking_block_max;
+      }
+      const int n_masking_steps = (!Is_causal || is_in_context)
+          ? 0 : n_masking_block_max - n_masking_block_min;
+
+      // Is_arbitrary: load warp only participates in __syncthreads__; math warp 1 does the work.
+      if constexpr (Is_arbitrary) {
+        __syncthreads();  // S_arb: wait for math warp 1 to write sValidBlockIds
+        n_block_max = *sn_valid_block_max;
+        n_block_min = 0;
+      }
+
+      // Early exit 2 (after Is_arbitrary): non-persistent paths still consume the per-tile S1.
+      if (((Is_causal || Is_local || Is_arbitrary) && n_block_max <= n_block_min) ||
+          m_block * kBlockM >= actual_seqlen_q) {
+        if constexpr (!Use_persistent) {
+          __syncthreads();  // S1
+        }
+        return;
+      }
+
+      // SMEM layout types for TMA partition_D.
+      using SmemLayoutK_SW128  = typename Kernel_traits::SmemLayoutK_TMA;
+      using SmemLayoutVt_SW128 = typename Kernel_traits::SmemLayoutVt_TMA;
+      using SmemLayoutQ_SW128  = typename Kernel_traits::SmemLayoutQ_TMA;
+      using SmemLayoutRab_TMA  = typename Kernel_traits::SmemLayoutRab_TMA;
+      using RabElement = cutlass::bfloat16_t;
+
+      constexpr int kSmemKVElems = kBlockN * kHeadDim;
+      FP8Elem* const sK_base[2] = {
+          reinterpret_cast<FP8Elem*>(smem_q),
+          Kernel_traits::kUseSingleKVStage
+              ? reinterpret_cast<FP8Elem*>(smem_q)
+              : reinterpret_cast<FP8Elem*>(smem_q) + 2 * kSmemKVElems
+      };
+      FP8Elem* const sVt_base[2] = {
+          reinterpret_cast<FP8Elem*>(smem_q) + kSmemKVElems,
+          Kernel_traits::kUseSingleKVStage
+              ? reinterpret_cast<FP8Elem*>(smem_q) + kSmemKVElems
+              : reinterpret_cast<FP8Elem*>(smem_q) + 3 * kSmemKVElems
+      };
+
+      // q_tma_mbar_ptr is initialized with the other WS mbarriers above.
+
+      // SF SMEM pointers.
+      static constexpr int kSmemSFOffset_WS = Kernel_traits::kSmemWsDataSizePadded;
+      int32_t* smem_sfa_ptr = reinterpret_cast<int32_t*>(smem_ + kSmemSFOffset_WS);
+      int32_t* smem_sfp_ptr = smem_sfa_ptr + kBlockM;
+      int32_t* const smem_sfb_ptr[2] = {
+          smem_sfa_ptr + 2 * kBlockM,
+          smem_sfa_ptr + 2 * kBlockM + kBlockN
+      };
+      int32_t* const smem_sfv_ptr[2] = {
+          smem_sfa_ptr + 2 * kBlockM + 2 * kBlockN,
+          smem_sfa_ptr + 2 * kBlockM + 3 * kBlockN
+      };
+
+      if constexpr (!Use_persistent) {
+        init_ws_mbarriers();
+        __syncthreads();  // S1: WS mbarriers visible to all warps.
+      }
+
+      // TMA tensor setup for K, V^T, SFB, SFV (load warps only).
+      const int bidh_kv = bidh / params.h_h_k_ratio;
+      constexpr int kSmemKBytes    = kBlockN * kHeadDim * (int)sizeof(FP8Elem);
+      constexpr int kSmemVtBytes   = kHeadDim * kBlockN * (int)sizeof(FP8Elem);
+      constexpr int kSmemSFBBytes  = kBlockN * (int)sizeof(int32_t);
+      constexpr int kSmemSFVBytes  = kBlockN * (int)sizeof(int32_t);
+      constexpr uint32_t kSmemKSFBBytes =
+          (uint32_t)(kSmemKBytes + kSmemSFBBytes);
+      constexpr uint32_t kSmemVtSFVBytes =
+          (uint32_t)(kSmemVtBytes + kSmemSFVBytes);
+      constexpr uint32_t kSmemRabBytes =
+          (uint32_t)(kBlockM * kBlockN * (int)sizeof(RabElement));
+
+      Tensor sValidBlockIds = make_tensor(
+          make_smem_ptr(reinterpret_cast<int*>(smem_ + Kernel_traits::kSmemWsValidBlockIdsOffset)),
+          typename Kernel_traits::SmemLayoutValidBlockIds{});
+
+      // ===== ROLE-SPECIALIZED LOAD WARPS =====
+      // Q/SFA warp issues the per-row-tile Q preamble. K/SFB and V/SFV warps independently
+      // feed the double-buffered N loop. O-store warp owns the final TMA store.  Q and O do
+      // not get extra buffers.  Producer/consumer mbarriers replace the old tile-end load
+      // rendezvous: load warps wait empty, math waits ready, and O-store waits O ready.
+      if constexpr (IsQLoadRole) {
+        wait_mbar_parity(q_empty_mbar_ptr, (uint32_t)q_empty_wait_parity);
+        q_empty_wait_parity ^= 1;
+        if (tidx == kNMathThreads) {
+          constexpr uint32_t kSmemQBytes   = kBlockM * kHeadDim * (uint32_t)sizeof(FP8Elem);
+          constexpr uint32_t kSmemSFABytes = kBlockM * (uint32_t)sizeof(int32_t);
+          using SmemLayoutSFA_TMA_t = cute::Layout<cute::Shape<cute::Int<kBlockM>, cute::Int<1>>,
+                                                   cute::Stride<cute::_1, cute::Int<kBlockM>>>;
+          auto mQ_tma   = params.tma_q.get_tma_tensor(make_shape(params.total_q, params.d, params.h));
+          auto gQ_head  = mQ_tma(_, _, bidh);
+          auto gQ_tiles = local_tile(gQ_head, Shape<Int<kBlockM>, Int<kHeadDim>>{}, make_coord(_, _));
+          auto tma_slice_Q = params.tma_q.get_slice(0);
+          auto sQ_buf      = make_tensor(
+              make_smem_ptr(reinterpret_cast<FP8Elem*>(
+                  reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsQPersistOffset)),
+              SmemLayoutQ_SW128{});
+          auto tQsQ_d      = tma_slice_Q.partition_D(sQ_buf);
+          auto tQgQ_tma    = tma_slice_Q.partition_S(gQ_tiles(_, _, _, Int<0>{}));
+          auto mSFA_tma    = params.tma_sfa.get_tma_tensor(
+              make_shape((int64_t)params.q_block_descale_head_stride, cute::Int<1>{}, params.h));
+          auto gSFA_head   = mSFA_tma(_, _, bidh);
+          auto gSFA_tiles  = local_tile(gSFA_head, Shape<Int<kBlockM>, Int<1>>{}, make_coord(_, _));
+          auto tma_slice_SFA = params.tma_sfa.get_slice(0);
+          auto tSFAsSFA_d    = tma_slice_SFA.partition_D(
+              make_tensor(make_smem_ptr(smem_sfa_ptr), SmemLayoutSFA_TMA_t{}));
+          auto tSFAgSFA_tma  = tma_slice_SFA.partition_S(gSFA_tiles(_, _, _, Int<0>{}));
+          arrive_expect_tx_mbar(q_ready_mbar_ptr, kSmemQBytes + kSmemSFABytes);
+          const int m_abs = binfo.sum_s_q / kBlockM + m_block;
+          cute::copy(params.tma_q.with(*q_ready_mbar_ptr),   tQgQ_tma(_, _, _, m_abs),     tQsQ_d);
+          cute::copy(params.tma_sfa.with(*q_ready_mbar_ptr), tSFAgSFA_tma(_, _, _, m_abs), tSFAsSFA_d);
+        }
+      }
+
+      if constexpr (Kernel_traits::kUseAliasedOBuffer && (IsKLoadRole || IsVLoadRole)) {
+        wait_mbar_parity(o_empty_mbar_ptr0, (uint32_t)o_empty_load_wait_parity0);
+        o_empty_load_wait_parity0 ^= 1;
+      }
+
+      if constexpr (IsKLoadRole) {
+        using SmemLayoutSFB_TMA_t = cute::Layout<cute::Shape<cute::Int<kBlockN>, cute::Int<1>>,
+                                                 cute::Stride<cute::_1, cute::Int<kBlockN>>>;
+
+        auto load_rab_tma = [&](int nb) {
+          if constexpr (Has_rab) {
+            wait_mbar_parity(rab_empty_mbar_ptr0, (uint32_t)rab_empty_wait_parity0);
+            rab_empty_wait_parity0 ^= 1;
+            if (tidx == kNMathThreads + 32) {
+              RabElement* smem_rab = reinterpret_cast<RabElement*>(
+                  reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsRabOffset);
+              Tensor sRab_tma = make_tensor(make_smem_ptr(smem_rab), SmemLayoutRab_TMA{});
+              const int bidh_rab = Has_rab && params.h_rab > 1 ? bidh : 0;
+              auto mRab_tma = params.tma_rab.get_tma_tensor(
+                  make_shape(params.seqlen_k_rounded, params.seqlen_k_rounded,
+                             Has_rab ? params.h_rab : 1, params.b))(_, _, bidh_rab, bidb);
+              auto gRab_tiles = local_tile(
+                  domain_offset(make_coord(actual_seqlen_offset, _0{}), mRab_tma),
+                  Shape<Int<kBlockM>, Int<kBlockN>>{}, make_coord(m_block, _));
+              auto tma_slice_Rab = params.tma_rab.get_slice(0);
+              auto tRabgRab_tma = group_modes<0, 3>(tma_slice_Rab.partition_S(gRab_tiles));
+              auto tRabsRab_d = group_modes<0, 3>(tma_slice_Rab.partition_D(sRab_tma));
+              arrive_expect_tx_mbar(rab_ready_mbar_ptr0, kSmemRabBytes);
+              cute::copy(params.tma_rab.with(*rab_ready_mbar_ptr0),
+                         tRabgRab_tma(_, nb), tRabsRab_d(_, _0{}));
+            }
+          }
+        };
+
+        if constexpr (Paged_KV) {
+          for (int n_valid = n_block_max - 1, masking_step_load = 0; n_valid >= n_block_min;
+               ++masking_step_load, --n_valid) {
+            const int nb = Is_arbitrary ? int(sValidBlockIds[n_valid]) : n_valid;
+
+            uint64_t* k_empty_mbar_ptr = kv_load_stage ? k_empty_mbar_ptr1 : k_empty_mbar_ptr0;
+            int& k_empty_wait_parity = kv_load_stage ? k_empty_wait_parity1 : k_empty_wait_parity0;
+            wait_mbar_parity(k_empty_mbar_ptr, (uint32_t)k_empty_wait_parity);
+            k_empty_wait_parity ^= 1;
+
+            uint64_t* k_ready_mbar_ptr = kv_load_stage ? k_ready_mbar_ptr1 : k_ready_mbar_ptr0;
+            if (tidx == kNMathThreads + 32) {
+              arrive_expect_tx_mbar(k_ready_mbar_ptr, kSmemKSFBBytes);
+              auto mSFB_tma = params.tma_sfb.get_tma_tensor(
+                  make_shape((int64_t)params.kv_block_descale_head_stride, cute::Int<1>{}, params.h_k));
+              auto gSFB_head_k = mSFB_tma(_, _, bidh_kv);
+              auto gSFB_tiles_k = local_tile(gSFB_head_k, Shape<Int<kBlockN>, Int<1>>{}, make_coord(_, _));
+              auto tma_slice_SFB = params.tma_sfb.get_slice(0);
+              auto tSFBgSFB_tma = tma_slice_SFB.partition_S(gSFB_tiles_k(_, _, _, Int<0>{}));
+              auto tSFBsSFB_d = tma_slice_SFB.partition_D(make_tensor(
+                  make_smem_ptr(kv_load_stage ? smem_sfb_ptr[1] : smem_sfb_ptr[0]),
+                  SmemLayoutSFB_TMA_t{}));
+              if (nb < n_block_paged) {
+                const int page_id = params.page_ids[page_offset + nb];
+                const int sf_page_block = (page_id * params.page_size) / kBlockN;
+                auto mK_page_tma = params.tma_k_page.get_tma_tensor(
+                    make_shape(params.page_size, params.d, params.h_k, params.total_pages));
+                auto gK_page_head = mK_page_tma(_, _, bidh_kv, _);
+                auto gK_page_tiles = local_tile(
+                    gK_page_head, Shape<Int<kBlockN>, Int<kHeadDim>>{}, make_coord(_, _));
+                auto tma_slice_K_page = params.tma_k_page.get_slice(0);
+                auto tKPgK_tma = tma_slice_K_page.partition_S(
+                    gK_page_tiles(_, _, _, Int<0>{}, _));
+                auto tKPsK_d = tma_slice_K_page.partition_D(make_tensor(
+                    make_smem_ptr(kv_load_stage ? sK_base[1] : sK_base[0]),
+                    SmemLayoutK_SW128{}));
+                cute::copy(params.tma_k_page.with(*k_ready_mbar_ptr),
+                           tKPgK_tma(_, _, _, Int<0>{}, page_id), tKPsK_d);
+                cute::copy(params.tma_sfb.with(*k_ready_mbar_ptr),
+                           tSFBgSFB_tma(_, _, _, sf_page_block), tSFBsSFB_d);
+              } else {
+                // Wrapper pads paged target K/V and packed SF to kBlockN-aligned
+                // physical blocks, so target tail uses the same TMA path as history.
+                const int target_block = nb - n_block_paged;
+                const int target_start = binfo.sum_s_k + actual_seqlen_k - actual_seqlen_t
+                    + last_page_offset + target_block * kBlockN;
+                const int nb_abs = target_start / kBlockN;
+                const int sf_abs = (params.total_pages * params.page_size + target_start) / kBlockN;
+                auto mK_tma = params.tma_k.get_tma_tensor(
+                    make_shape(params.total_k, params.d, params.h_k));
+                auto gK_head = mK_tma(_, _, bidh_kv);
+                auto gK_tiles = local_tile(
+                    gK_head, Shape<Int<kBlockN>, Int<kHeadDim>>{}, make_coord(_, _));
+                auto tma_slice_K = params.tma_k.get_slice(0);
+                auto tKgK_tma = tma_slice_K.partition_S(gK_tiles(_, _, _, Int<0>{}));
+                auto tKsK_d = tma_slice_K.partition_D(make_tensor(
+                    make_smem_ptr(kv_load_stage ? sK_base[1] : sK_base[0]),
+                    SmemLayoutK_SW128{}));
+                cute::copy(params.tma_k.with(*k_ready_mbar_ptr),
+                           tKgK_tma(_, _, _, nb_abs), tKsK_d);
+                cute::copy(params.tma_sfb.with(*k_ready_mbar_ptr),
+                           tSFBgSFB_tma(_, _, _, sf_abs), tSFBsSFB_d);
+              }
+            }
+            load_rab_tma(nb);
+
+            if (is_jump && masking_step_load == n_masking_steps - 1)
+              n_valid = std::min(n_valid, n_block_history);
+
+            if constexpr (!Kernel_traits::kUseSingleKVStage) {
+              kv_load_stage ^= 1;
+            }
+          }
+        } else {
+          for (int n_valid = n_block_max - 1, masking_step_load = 0; n_valid >= n_block_min;
+               ++masking_step_load, --n_valid) {
+            const int nb = Is_arbitrary ? int(sValidBlockIds[n_valid]) : n_valid;
+
+            uint64_t* k_empty_mbar_ptr = kv_load_stage ? k_empty_mbar_ptr1 : k_empty_mbar_ptr0;
+            int& k_empty_wait_parity = kv_load_stage ? k_empty_wait_parity1 : k_empty_wait_parity0;
+            wait_mbar_parity(k_empty_mbar_ptr, (uint32_t)k_empty_wait_parity);
+            k_empty_wait_parity ^= 1;
+
+            if (tidx == kNMathThreads + 32) {
+              const int nb_abs = binfo.sum_s_k / kBlockN + nb;
+              uint64_t* k_ready_mbar_ptr = kv_load_stage ? k_ready_mbar_ptr1 : k_ready_mbar_ptr0;
+              auto mK_tma = params.tma_k.get_tma_tensor(make_shape(params.total_k, params.d, params.h_k));
+              auto gK_head = mK_tma(_, _, bidh_kv);
+              auto gK_tiles = local_tile(gK_head, Shape<Int<kBlockN>, Int<kHeadDim>>{}, make_coord(_, _));
+              auto tma_slice_K = params.tma_k.get_slice(0);
+              auto tKgK_tma = tma_slice_K.partition_S(gK_tiles(_, _, _, Int<0>{}));
+              auto tKsK_d = tma_slice_K.partition_D(make_tensor(
+                  make_smem_ptr(kv_load_stage ? sK_base[1] : sK_base[0]),
+                  SmemLayoutK_SW128{}));
+              auto mSFB_tma = params.tma_sfb.get_tma_tensor(
+                  make_shape((int64_t)params.kv_block_descale_head_stride, cute::Int<1>{}, params.h_k));
+              auto gSFB_head_k = mSFB_tma(_, _, bidh_kv);
+              auto gSFB_tiles_k = local_tile(gSFB_head_k, Shape<Int<kBlockN>, Int<1>>{}, make_coord(_, _));
+              auto tma_slice_SFB = params.tma_sfb.get_slice(0);
+              auto tSFBgSFB_tma = tma_slice_SFB.partition_S(gSFB_tiles_k(_, _, _, Int<0>{}));
+              auto tSFBsSFB_d = tma_slice_SFB.partition_D(make_tensor(
+                  make_smem_ptr(kv_load_stage ? smem_sfb_ptr[1] : smem_sfb_ptr[0]),
+                  SmemLayoutSFB_TMA_t{}));
+              arrive_expect_tx_mbar(k_ready_mbar_ptr, kSmemKSFBBytes);
+              cute::copy(params.tma_k.with(*k_ready_mbar_ptr), tKgK_tma(_, _, _, nb_abs), tKsK_d);
+              cute::copy(params.tma_sfb.with(*k_ready_mbar_ptr), tSFBgSFB_tma(_, _, _, nb_abs), tSFBsSFB_d);
+            }
+            load_rab_tma(nb);
+
+            if (is_jump && masking_step_load == n_masking_steps - 1)
+              n_valid = std::min(n_valid, n_block_history);
+
+            if constexpr (!Kernel_traits::kUseSingleKVStage) {
+              kv_load_stage ^= 1;
+            }
+          }
+        }
+      }
+
+      if constexpr (IsVLoadRole) {
+        using SmemLayoutSFV_TMA_t = cute::Layout<cute::Shape<cute::Int<kBlockN>, cute::Int<1>>,
+                                                 cute::Stride<cute::_1, cute::Int<kBlockN>>>;
+
+        if constexpr (Paged_KV) {
+          for (int n_valid = n_block_max - 1, masking_step_load = 0; n_valid >= n_block_min;
+               ++masking_step_load, --n_valid) {
+            const int nb = Is_arbitrary ? int(sValidBlockIds[n_valid]) : n_valid;
+
+            uint64_t* v_empty_mbar_ptr = kv_load_stage ? v_empty_mbar_ptr1 : v_empty_mbar_ptr0;
+            int& v_empty_wait_parity = kv_load_stage ? v_empty_wait_parity1 : v_empty_wait_parity0;
+            wait_mbar_parity(v_empty_mbar_ptr, (uint32_t)v_empty_wait_parity);
+            v_empty_wait_parity ^= 1;
+
+            if (tidx == kNMathThreads + 64) {
+              uint64_t* v_ready_mbar_ptr = kv_load_stage ? v_ready_mbar_ptr1 : v_ready_mbar_ptr0;
+              arrive_expect_tx_mbar(v_ready_mbar_ptr, kSmemVtSFVBytes);
+              auto mSFV_tma = params.tma_sfv.get_tma_tensor(
+                  make_shape((int64_t)params.v_block_descale_head_stride, cute::Int<1>{}, params.h_k));
+              auto gSFV_head_k = mSFV_tma(_, _, bidh_kv);
+              auto gSFV_tiles_k = local_tile(gSFV_head_k, Shape<Int<kBlockN>, Int<1>>{}, make_coord(_, _));
+              auto tma_slice_SFV = params.tma_sfv.get_slice(0);
+              auto tSFVgSFV_tma = tma_slice_SFV.partition_S(gSFV_tiles_k(_, _, _, Int<0>{}));
+              auto tSFVsSFV_d = tma_slice_SFV.partition_D(make_tensor(
+                  make_smem_ptr(kv_load_stage ? smem_sfv_ptr[1] : smem_sfv_ptr[0]),
+                  SmemLayoutSFV_TMA_t{}));
+              if (nb < n_block_paged) {
+                const int page_id = params.page_ids[page_offset + nb];
+                const int sf_page_block = (page_id * params.page_size) / kBlockN;
+                auto mVt_page_tma = params.tma_vt_page.get_tma_tensor(
+                    make_shape(params.page_size, params.d, params.h_k, params.total_pages));
+                auto gVt_page_head = mVt_page_tma(_, _, bidh_kv, _);
+                auto gVt_page_tiles = local_tile(
+                    gVt_page_head, Shape<Int<kBlockN>, Int<kHeadDim>>{}, make_coord(_, _));
+                auto tma_slice_Vt_page = params.tma_vt_page.get_slice(0);
+                auto tVPgVt_tma = tma_slice_Vt_page.partition_S(
+                    gVt_page_tiles(_, _, _, Int<0>{}, _));
+                auto tVPsVt_d = tma_slice_Vt_page.partition_D(make_tensor(
+                    make_smem_ptr(kv_load_stage ? sVt_base[1] : sVt_base[0]),
+                    SmemLayoutVt_SW128{}));
+                cute::copy(params.tma_vt_page.with(*v_ready_mbar_ptr),
+                           tVPgVt_tma(_, _, _, Int<0>{}, page_id), tVPsVt_d);
+                cute::copy(params.tma_sfv.with(*v_ready_mbar_ptr),
+                           tSFVgSFV_tma(_, _, _, sf_page_block), tSFVsSFV_d);
+              } else {
+                // Wrapper pads paged target K/V and packed SF to kBlockN-aligned
+                // physical blocks, so target tail uses the same TMA path as history.
+                const int target_block = nb - n_block_paged;
+                const int target_start = binfo.sum_s_k + actual_seqlen_k - actual_seqlen_t
+                    + last_page_offset + target_block * kBlockN;
+                const int nb_abs = target_start / kBlockN;
+                const int sf_abs = (params.total_pages * params.page_size + target_start) / kBlockN;
+                auto mVt_tma = params.tma_vt.get_tma_tensor(
+                    make_shape(params.total_k, params.d, params.h_k));
+                auto gVt_head = mVt_tma(_, _, bidh_kv);
+                auto gVt_tiles = local_tile(
+                    gVt_head, Shape<Int<kBlockN>, Int<kHeadDim>>{}, make_coord(_, _));
+                auto tma_slice_Vt = params.tma_vt.get_slice(0);
+                auto tVtgVt_tma = tma_slice_Vt.partition_S(gVt_tiles(_, _, _, Int<0>{}));
+                auto tVtsVt_d = tma_slice_Vt.partition_D(make_tensor(
+                    make_smem_ptr(kv_load_stage ? sVt_base[1] : sVt_base[0]),
+                    SmemLayoutVt_SW128{}));
+                cute::copy(params.tma_vt.with(*v_ready_mbar_ptr),
+                           tVtgVt_tma(_, _, _, nb_abs), tVtsVt_d);
+                cute::copy(params.tma_sfv.with(*v_ready_mbar_ptr),
+                           tSFVgSFV_tma(_, _, _, sf_abs), tSFVsSFV_d);
+              }
+            }
+
+            if (is_jump && masking_step_load == n_masking_steps - 1)
+              n_valid = std::min(n_valid, n_block_history);
+
+            if constexpr (!Kernel_traits::kUseSingleKVStage) {
+              kv_load_stage ^= 1;
+            }
+          }
+        } else {
+          for (int n_valid = n_block_max - 1, masking_step_load = 0; n_valid >= n_block_min;
+               ++masking_step_load, --n_valid) {
+            const int nb = Is_arbitrary ? int(sValidBlockIds[n_valid]) : n_valid;
+
+            uint64_t* v_empty_mbar_ptr = kv_load_stage ? v_empty_mbar_ptr1 : v_empty_mbar_ptr0;
+            int& v_empty_wait_parity = kv_load_stage ? v_empty_wait_parity1 : v_empty_wait_parity0;
+            wait_mbar_parity(v_empty_mbar_ptr, (uint32_t)v_empty_wait_parity);
+            v_empty_wait_parity ^= 1;
+
+            if (tidx == kNMathThreads + 64) {
+              const int nb_abs = binfo.sum_s_k / kBlockN + nb;
+              uint64_t* v_ready_mbar_ptr = kv_load_stage ? v_ready_mbar_ptr1 : v_ready_mbar_ptr0;
+              auto mVt_tma = params.tma_vt.get_tma_tensor(make_shape(params.total_k, params.d, params.h_k));
+              auto gVt_head = mVt_tma(_, _, bidh_kv);
+              auto gVt_tiles = local_tile(gVt_head, Shape<Int<kBlockN>, Int<kHeadDim>>{}, make_coord(_, _));
+              auto tma_slice_Vt = params.tma_vt.get_slice(0);
+              auto tVtgVt_tma = tma_slice_Vt.partition_S(gVt_tiles(_, _, _, Int<0>{}));
+              auto tVtsVt_d = tma_slice_Vt.partition_D(make_tensor(
+                  make_smem_ptr(kv_load_stage ? sVt_base[1] : sVt_base[0]),
+                  SmemLayoutVt_SW128{}));
+              auto mSFV_tma = params.tma_sfv.get_tma_tensor(
+                  make_shape((int64_t)params.v_block_descale_head_stride, cute::Int<1>{}, params.h_k));
+              auto gSFV_head_k = mSFV_tma(_, _, bidh_kv);
+              auto gSFV_tiles_k = local_tile(gSFV_head_k, Shape<Int<kBlockN>, Int<1>>{}, make_coord(_, _));
+              auto tma_slice_SFV = params.tma_sfv.get_slice(0);
+              auto tSFVgSFV_tma = tma_slice_SFV.partition_S(gSFV_tiles_k(_, _, _, Int<0>{}));
+              auto tSFVsSFV_d = tma_slice_SFV.partition_D(make_tensor(
+                  make_smem_ptr(kv_load_stage ? smem_sfv_ptr[1] : smem_sfv_ptr[0]),
+                  SmemLayoutSFV_TMA_t{}));
+              arrive_expect_tx_mbar(v_ready_mbar_ptr, kSmemVtSFVBytes);
+              cute::copy(params.tma_vt.with(*v_ready_mbar_ptr), tVtgVt_tma(_, _, _, nb_abs), tVtsVt_d);
+              cute::copy(params.tma_sfv.with(*v_ready_mbar_ptr), tSFVgSFV_tma(_, _, _, nb_abs), tSFVsSFV_d);
+            }
+
+            if (is_jump && masking_step_load == n_masking_steps - 1)
+              n_valid = std::min(n_valid, n_block_history);
+
+            if constexpr (!Kernel_traits::kUseSingleKVStage) {
+              kv_load_stage ^= 1;
+            }
+          }
+        }
+      }
+
+      if constexpr (IsOStoreRole) {
+        if constexpr (Kernel_traits::kUseTmaOStore) {
+        // Math warps own compute/softmax and write O to independent SMEM; O-store waits
+        // for o_ready[0], then releases o_empty[0] after the TMA store completes.
+        wait_mbar_parity(o_ready_mbar_ptr0, (uint32_t)o_ready_wait_parity0);
+        o_ready_wait_parity0 ^= 1;
+        if (tidx == kNMathThreads + 96) {
+          asm volatile("fence.proxy.async.shared::cta;\n" : : : "memory");
+          static_assert(
+              Kernel_traits::kSmemWsOStoreBytes >= kBlockM * kHeadDim * (int)sizeof(OutElement),
+              "O SMEM buffer is too small.");
+          char* smem_o = reinterpret_cast<char*>(smem_) +
+              (Kernel_traits::kUseAliasedOBuffer ? 0 : Kernel_traits::kSmemWsOOffset);
+          Tensor sO_tma = make_tensor(
+              make_smem_ptr(reinterpret_cast<OutElement*>(smem_o)),
+              typename Kernel_traits::SmemLayoutWsO_TMA{});
+          auto mO_tma   = params.tma_o.get_tma_tensor(make_shape(params.total_q, params.d, params.h));
+          auto gO_head  = mO_tma(_, _, bidh);
+          auto gO_tiles = local_tile(gO_head, Shape<Int<kBlockM>, Int<kHeadDim>>{}, make_coord(_, _));
+          const int m_abs = binfo.sum_s_q / kBlockM + m_block;
+          auto tma_slice_O = params.tma_o.get_slice(0);
+          Tensor tOsO     = tma_slice_O.partition_S(sO_tma);
+          Tensor tOgO_all = tma_slice_O.partition_D(gO_tiles(_, _, _, Int<0>{}));
+          cute::copy(params.tma_o, tOsO, tOgO_all(_, _, _, m_abs));
+          cute::tma_store_arrive();
+          cute::tma_store_wait<0>();
+          arrive_mbar(o_empty_mbar_ptr0);
+        }
+        }
+      }
+    };
+
+    // Static tile-id broadcast: load and math paths run the same deterministic
+    // scheduler and decode the same tile ids locally.  There is no dynamic work
+    // queue, atomic counter, or shared tile-id sync on this path.
+    const bool head_shared_rab = Has_rab && params.h_rab == 1 && params.h > 1;
+    auto run_load_store_scheduler = [&](auto load_role) {
+      if constexpr (Use_paired_persistent) {
+        const int num_m_block_persistent = Use_actual_target_scheduler
+            ? num_m_block_scheduler
+            : num_m_block_capacity;
+        if constexpr (Use_actual_target_scheduler) {
+          const int pairs_per_bh = (num_m_block_persistent + 1) / 2;
+          const int total_tile_pairs_persistent =
+              pairs_per_bh * params.h * params.b;
+          #pragma unroll 1
+          for (int tile_pair = int(blockIdx.x); tile_pair < total_tile_pairs_persistent; tile_pair += int(gridDim.x)) {
+            const int pair_idx = tile_pair % pairs_per_bh;
+            const int bh = tile_pair / pairs_per_bh;
+            const int bidb = bh / params.h;
+            const int bidh = bh - bidb * params.h;
+            const int m_hi = num_m_block_persistent - 1 - pair_idx;
+            const int m_lo = pair_idx;
+
+            run_load_store_tile(load_role, bidb, bidh, m_hi);
+            if (m_lo != m_hi) {
+              run_load_store_tile(load_role, bidb, bidh, m_lo);
+            }
+          }
+        } else {
+          const int total_tiles_persistent = num_m_block_persistent * params.h * params.b;
+          const int total_tile_pairs_persistent = (total_tiles_persistent + 1) / 2;
+          #pragma unroll 1
+          for (int tile_pair = int(blockIdx.x); tile_pair < total_tile_pairs_persistent; tile_pair += int(gridDim.x)) {
+            const int paired_tile = total_tiles_persistent - 1 - tile_pair;
+            const int tiles_this_pair = paired_tile == tile_pair ? 1 : 2;
+
+            #pragma unroll 1
+            for (int pair_slot = 0; pair_slot < tiles_this_pair; ++pair_slot) {
+              const int tile = pair_slot == 0 ? tile_pair : paired_tile;
+              const HstuWsTileCoord coord =
+                  hstu_ws_decode_tile(tile, num_m_block_persistent, params.h, head_shared_rab);
+              run_load_store_tile(load_role, coord.bidb, coord.bidh, coord.m_block);
+            }
+          }
+        }
+      } else if constexpr (Use_full_persistent) {
+        const int num_m_block_persistent = Use_actual_target_scheduler
+            ? num_m_block_scheduler
+            : num_m_block_capacity;
+        const int total_tiles_persistent = num_m_block_persistent * params.h * params.b;
+        #pragma unroll 1
+        for (int tile = int(blockIdx.x); tile < total_tiles_persistent; tile += int(gridDim.x)) {
+          const HstuWsTileCoord coord =
+              hstu_ws_decode_tile(tile, num_m_block_persistent, params.h, head_shared_rab);
+          run_load_store_tile(load_role, coord.bidb, coord.bidh, coord.m_block);
+        }
+      } else {
+        run_load_store_tile(load_role, bidb_arg, bidh_arg, m_block_arg);
+      }
+    };
+
+    if (is_q_load_warp) {
+      run_load_store_scheduler(std::integral_constant<int, 0>{});
+    } else if (is_k_load_warp) {
+      run_load_store_scheduler(std::integral_constant<int, 1>{});
+    } else if (is_v_load_warp) {
+      run_load_store_scheduler(std::integral_constant<int, 2>{});
+    } else {
+      run_load_store_scheduler(std::integral_constant<int, 3>{});
+    }
+    // Load warp path exits here.  Active load warp has also completed O TMA-store.
+
+  // ============================================================
+  } else {
+  // MATH WARP PATH  (warps 0-7, threads 0-255)
+  // ============================================================
+    if constexpr (
+        Kernel_traits::kHeadDim > 128 &&
+        Kernel_traits::Paged_KV &&
+        Kernel_traits::Has_rab) {
+      asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;" : : "n"(216));
+    } else if constexpr (Kernel_traits::kHeadDim > 128) {
+      asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;" : : "n"(232));
+    } else if constexpr (Kernel_traits::Paged_KV) {
+      asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;" : : "n"(216));
+    } else {
+      asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;" : : "n"(224));
+    }
+
+    constexpr bool Is_causal    = Kernel_traits::Is_causal;
+    constexpr bool Is_target    = Kernel_traits::Is_target;
+    constexpr bool Is_context   = Kernel_traits::Is_context;
+    constexpr bool Is_arbitrary = Kernel_traits::Is_arbitrary;
+    constexpr int  kNFunc       = Kernel_traits::kNFunc;
+    constexpr bool Is_local     = Kernel_traits::Is_local;
+    constexpr bool Has_rab      = Kernel_traits::Has_rab;
+    constexpr bool Paged_KV     = Kernel_traits::Paged_KV;
+    constexpr int  kBlockM      = Kernel_traits::kBlockM;
+    constexpr int  kBlockN      = Kernel_traits::kBlockN;
+    constexpr int  kHeadDim     = Kernel_traits::kHeadDim;
+    using RabElement = cutlass::bfloat16_t;
+
+    const int tidx_math = tidx;  // math warps: tidx_math == tidx (0-255)
+    int tma_parity0 = 0;  // Persistent K/V mbarrier parity for stage 0.
+    int tma_parity1 = 0;  // Persistent K/V mbarrier parity for stage 1.
+    int q_tma_parity = 0;
+    int o_empty_wait_parity = 0;
+    int rab_ready_wait_parity0 = 0;
+    int math_stage  = 0;
+
+    if constexpr (Use_persistent) {
+      __syncthreads();  // One-time S1: load warp has initialized K/V mbarriers.
+    }
+
+    auto run_math_tile = [&](const int bidb, const int bidh, int m_block) {
+      const HstuBlockInfo<Kernel_traits, Params> binfo(params, bidb);
+      // Early exit 1: before any sync — both branches exit simultaneously.
+      if (m_block * kBlockM >= binfo.actual_seqlen_q_padded) return;
+
+      char* smem_q    = reinterpret_cast<char*>(smem_);
+      char* smem_func = reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsFuncOffset;
+      int* sn_valid_block_max = reinterpret_cast<int*>(smem_func);
+      int* sf_min_ptr = reinterpret_cast<int*>(sn_valid_block_max) + 1;
+      int* sf_max_ptr = sf_min_ptr + (kNFunc/2 + 1);
+
+      const int actual_seqlen_q        = binfo.actual_seqlen_q;
+      const int actual_seqlen_k        = binfo.actual_seqlen_k;
+      const int actual_seqlen_q_padded = binfo.actual_seqlen_q_padded;
+      const int actual_seqlen_t        = Is_target  ? binfo.actual_seqlen_t : 0;
+      const int actual_seqlen_c        = Is_context ? binfo.actual_seqlen_c : 0;
+      const int actual_seqlen_h        = Is_target  ? actual_seqlen_k - actual_seqlen_t : actual_seqlen_k;
+      const int actual_seqlen_offset   = actual_seqlen_k - actual_seqlen_q;
+      const int last_page_seqlen       = Paged_KV ? binfo.last_page_seqlen : kBlockN;
+
+      const bool is_jump             = Is_target && m_block * kBlockM + actual_seqlen_offset > actual_seqlen_h;
+      const bool is_in_target        = Is_target && (m_block + 1) * kBlockM + actual_seqlen_offset > actual_seqlen_h;
+      const bool is_in_context       = Is_context && (m_block + 1) * kBlockM <= actual_seqlen_c;
+      const bool is_in_mixed_context = Is_context &&
+          (m_block + 1) * kBlockM > actual_seqlen_c && m_block * kBlockM < actual_seqlen_c;
+      const bool is_in_paged_target  = is_in_target && Paged_KV;
+      const int last_page_offset     = is_in_paged_target ? kBlockN - last_page_seqlen : 0;
+
+      const int n_block_history = cute::ceil_div(actual_seqlen_h, kBlockN);
+      const int n_block_paged   = Paged_KV ? n_block_history : 0;
+      const int n_block_target  = cute::ceil_div(actual_seqlen_t, kBlockN);
+
+      int n_block_min = !Is_local ? 0
+          : std::max(0, (m_block * kBlockM + actual_seqlen_offset - params.window_size_left) / kBlockN);
+      int n_block_max = Paged_KV ? n_block_history + n_block_target : cute::ceil_div(actual_seqlen_k, kBlockN);
+      if constexpr (Is_causal || Is_local) {
+        int offset = (m_block + 1) * kBlockM + actual_seqlen_offset + params.window_size_right;
+        if (is_in_paged_target) offset += last_page_offset;
+        n_block_max = std::min(n_block_max, cute::ceil_div(offset, kBlockN));
+      }
+      if constexpr (Is_context) {
+        n_block_min = (is_in_context || is_in_mixed_context) ? 0 : n_block_min;
+        n_block_max = (is_in_context || is_in_mixed_context)
+            ? std::max(n_block_history, n_block_max) : n_block_max;
+      }
+
+      int n_masking_block_max = cute::ceil_div(
+          std::min(actual_seqlen_k + last_page_offset,
+                   (m_block + 1) * kBlockM + actual_seqlen_offset + last_page_offset),
+          kBlockN);
+      int n_masking_block_min = (m_block * kBlockM + actual_seqlen_offset) / kBlockN;
+      if constexpr (Is_target) {
+        if constexpr (Target_group_size_1) {
+          n_masking_block_min = is_jump
+              ? (m_block * kBlockM + actual_seqlen_offset + last_page_offset) / kBlockN
+              : n_masking_block_min;
+        } else {
+          const int target_index =
+              (m_block * kBlockM - actual_seqlen_h) / params.target_group_size;
+          n_masking_block_min = is_jump
+              ? (actual_seqlen_h + actual_seqlen_offset +
+                 target_index * params.target_group_size + last_page_offset) / kBlockN
+              : n_masking_block_min;
+        }
+      }
+      if constexpr (Is_context) {
+        n_masking_block_min = is_in_mixed_context ? n_block_min : n_masking_block_min;
+        n_masking_block_max = is_in_mixed_context ? n_block_max : n_masking_block_max;
+      }
+      const int n_masking_steps = (!Is_causal || is_in_context)
+          ? 0 : n_masking_block_max - n_masking_block_min;
+
+      // Arbitrary func GMEM tensors (only needed when Is_arbitrary, but declared always for lambda).
+      Tensor mMaxFunc = make_tensor(
+          make_gmem_ptr(reinterpret_cast<int*>(params.func_ptr) + binfo.sum_s_q),
+          make_shape(Int<1>{}, Int<kNFunc/2 + 1>{}, actual_seqlen_q),
+          make_stride(params.func_head_stride, 2 * params.func_ids_stride, _1{}));
+      Tensor mMinFunc = make_tensor(
+          make_gmem_ptr(reinterpret_cast<int*>(params.func_ptr) + binfo.sum_s_q + params.func_ids_stride),
+          make_shape(Int<1>{}, Int<kNFunc/2>{}, actual_seqlen_q),
+          make_stride(params.func_head_stride, 2 * params.func_ids_stride, _1{}));
+      Tensor gMaxFunc = local_tile(mMaxFunc(Int<0>{}, _, _),
+          make_shape(Int<kNFunc/2 + 1>{}, Int<kBlockM>{}), make_coord(Int<0>{}, m_block));
+      Tensor gMinFunc = local_tile(mMinFunc(Int<0>{}, _, _),
+          make_shape(Int<kNFunc/2>{}, Int<kBlockM>{}), make_coord(Int<0>{}, m_block));
+
+      // SMEM tensors for Is_arbitrary.
+      Tensor sValidBlockIds = make_tensor(
+          make_smem_ptr(reinterpret_cast<int*>(smem_ + Kernel_traits::kSmemWsValidBlockIdsOffset)),
+          typename Kernel_traits::SmemLayoutValidBlockIds{});
+      Tensor sFunc_min = make_tensor(make_smem_ptr(sf_min_ptr), typename Kernel_traits::SmemLayoutMinFunc{});
+      Tensor sFunc_max = make_tensor(make_smem_ptr(sf_max_ptr), typename Kernel_traits::SmemLayoutMaxFunc{});
+
+      // Is_arbitrary setup: warp 1 (threads 32-63) does the computation; load warp just syncs.
+      if constexpr (Is_arbitrary) {
+        const int lane_id = cutlass::canonical_lane_idx();
+        const int warp_id = cutlass::canonical_warp_idx_sync();
+        if (warp_id == 1) {
+          *sn_valid_block_max = 0;
+          sFunc_min[0] = 0;
+          __syncwarp();
+          int f_min = INT_MAX, f_max = INT_MIN;
+          const int base_row = m_block * kBlockM;
+          for (int i = 0; i < size<0>(gMinFunc); i++) {
+            for (int j = lane_id; j < size<1>(gMinFunc); j += 32) {
+              const int row = base_row + j;
+              if (row < actual_seqlen_q) if (f_min > gMinFunc(i, j)) f_min = gMinFunc(i, j);
+            }
+            warpReduce(f_min, MinOp<int>());
+            if (lane_id == 0) sFunc_min[i+1] = f_min;
+            f_min = INT_MAX;
+          }
+          for (int i = 0; i < size<0>(gMaxFunc); i++) {
+            for (int j = lane_id; j < size<1>(gMaxFunc); j += 32) {
+              const int row = base_row + j;
+              if (row < actual_seqlen_q) if (f_max < gMaxFunc(i, j)) f_max = gMaxFunc(i, j);
+            }
+            warpReduce(f_max, MaxOp<int>());
+            if (lane_id == 0) sFunc_max[i] = f_max;
+            f_max = INT_MIN;
+          }
+          if (lane_id == 0) {
+            for (int n_block = n_block_min; n_block < n_block_max; n_block++) {
+              int b_max = (n_block + 1) * kBlockN, b_min = n_block * kBlockN;
+              for (int i = 0; i < (kNFunc + 1)/2; i++) {
+                int fmin = sFunc_min[i], fmax = sFunc_max[i];
+                if (fmax <= fmin) continue;
+                bool c1 = fmin <= b_min && fmax > b_min;
+                bool c2 = fmin >= b_min && b_max > fmin;
+                bool c3 = fmin >= b_min && fmax < b_max;
+                if (c1 || c2 || c3) {
+                  sValidBlockIds[*sn_valid_block_max] = n_block;
+                  (*sn_valid_block_max)++;
+                  break;
+                }
+              }
+            }
+          }
+        }
+        __syncthreads();  // S_arb: sValidBlockIds written by warp 1, visible to all (incl. load warp).
+        n_block_max = *sn_valid_block_max;
+        n_block_min = 0;
+      }
+
+      // Early exit 2 (after Is_arbitrary): math warps write zeros; non-persistent paths still
+      // consume the per-tile S1.
+      if (((Is_causal || Is_local || Is_arbitrary) && n_block_max <= n_block_min) ||
+          m_block * kBlockM >= actual_seqlen_q) {
+        using OutElement = typename Kernel_traits::OutputType;
+        Tensor mO = make_tensor(
+            make_gmem_ptr(reinterpret_cast<OutElement*>(params.o_ptr) + binfo.q_offset(params.o_row_stride)),
+            make_shape(actual_seqlen_q, params.h, params.d),
+            make_stride(params.o_row_stride, params.o_head_stride, _1{}));
+        Tensor gO = local_tile(mO(_, bidh, _), Shape<Int<kBlockM>, Int<kHeadDim>>{}, make_coord(m_block, 0));
+        typename Kernel_traits::GmemTiledCopyO gmem_tiled_copy_O;
+        auto gmem_thr_copy_O = gmem_tiled_copy_O.get_thread_slice(tidx_math);
+        Tensor tOgO = gmem_thr_copy_O.partition_D(gO);
+        Tensor tOrO = make_tensor<OutElement>(shape(tOgO));
+        clear(tOrO);
+        Tensor cO_zr = make_identity_tensor(make_shape(size<0>(gO), size<1>(gO)));
+        Tensor tOcO = gmem_thr_copy_O.partition_D(cO_zr);
+        flash::copy<false, false, false>(gmem_tiled_copy_O, tOrO, tOgO, tOcO,
+            actual_seqlen_q_padded - m_block * kBlockM);
+        if constexpr (!Use_persistent) {
+          __syncthreads();  // S1
+        }
+        return;
+      }
+
+      // WS SMEM layouts. Kernel_traits selects SW32/SW64/SW128 by headDim.
+      using SmemLayoutQ_SW128  = typename Kernel_traits::SmemLayoutQ_TMA;
+      using SmemLayoutK_SW128  = typename Kernel_traits::SmemLayoutK_TMA;
+
+      constexpr int kSmemKVElems = kBlockN * kHeadDim;
+
+      // smem_base32: shared-memory base address as uint32 for on-demand barrier/KV
+      // pointer computation in the main loop — replaces 6 persistent pointer arrays.
+      const uint32_t smem_base32 =
+          static_cast<uint32_t>(__cvta_generic_to_shared(smem_));
+      uint64_t* q_ready_mbar_ptr = reinterpret_cast<uint64_t*>(
+          reinterpret_cast<char*>(smem_) + kSmemMbar0Offset + 64);
+      uint64_t* q_empty_mbar_ptr = reinterpret_cast<uint64_t*>(
+          reinterpret_cast<char*>(smem_) + kSmemMbar0Offset + 72);
+
+      // SF SMEM pointers.
+      static constexpr int kSmemSFOffset_WS = Kernel_traits::kSmemWsDataSizePadded;
+      int32_t* smem_sfa_ptr = reinterpret_cast<int32_t*>(smem_ + kSmemSFOffset_WS);
+      int32_t* smem_sfp_ptr = smem_sfa_ptr + kBlockM;
+
+      using SmemLayoutSFA = typename BS1::SmemLayoutSFA;
+      using SmemLayoutSFB = typename BS1::SmemLayoutSFB;
+      using SmemLayoutSFV = typename BS2::SmemLayoutSFB;
+      Tensor sSFA_ = make_tensor(make_smem_ptr(smem_sfa_ptr), SmemLayoutSFA{});
+      auto sSFA = as_position_independent_swizzle_tensor(sSFA_);
+      Tensor sSFP_ = make_tensor(make_smem_ptr(smem_sfp_ptr), SmemLayoutSFA{});
+      auto sSFP = as_position_independent_swizzle_tensor(sSFP_);
+      using SmemLayoutRab_TMA = typename Kernel_traits::SmemLayoutRab_TMA;
+      RabElement* smem_rab = reinterpret_cast<RabElement*>(
+          reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsRabOffset);
+      Tensor sRab = make_tensor(make_smem_ptr(smem_rab), SmemLayoutRab_TMA{});
+
+      // MMA tiled objects (use tidx_math = tidx for math warps).
+      typename BS1::TiledMma tiled_mma_g1;
+      auto thr_mma_g1 = tiled_mma_g1.get_thread_slice(tidx_math);
+      typename BS2::TiledMma tiled_mma_g2;
+      auto thr_mma_g2 = tiled_mma_g2.get_thread_slice(tidx_math);
+
+      Tensor acc_o = partition_fragment_C(tiled_mma_g2, Shape<Int<kBlockM>, Int<kHeadDimGemm2>>{});
+      clear(acc_o);
+
+      // s2r copy atoms. Q/P use explicit CuTe LDSM_N tiling below; K uses the
+      // standard B tiled copy, and V^T still uses LDSM_T inline PTX.
+      // SFB/SFV: get_layoutSFB_TV degenerates under AtomLayout <_8,_1,_1> (ThrN=1 → all
+      // threads map to SMEM position 0). Use direct SMEM reads at the call site instead.
+      auto s2r_copy_SFP = make_tiled_copy_impl(typename BS2::SmemCopyAtomSF{},
+          BS2::get_layoutSFA_TV(tiled_mma_g2), make_shape(size<0>(tile_shape(tiled_mma_g2)), _1{}));
+      auto s2r_thr_SFP  = s2r_copy_SFP.get_thread_slice(tidx_math);
+      auto s2r_copy_B_g1 = make_tiled_copy_B(typename BS1::SmemCopyAtomB{}, tiled_mma_g1);
+      auto s2r_thr_B_g1  = s2r_copy_B_g1.get_thread_slice(tidx_math);
+
+      if constexpr (!Use_persistent) {
+        __syncthreads();  // S1: tma_mbar0/1 and math_mbar0/1 visible to all warps.
+      }
+
+      FP8Elem* q_persist_base = reinterpret_cast<FP8Elem*>(
+          reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsQPersistOffset);
+      Tensor sQ_persist = make_tensor(
+          make_smem_ptr(q_persist_base),
+          SmemLayoutQ_SW128{});
+      auto sQ_persist_pi = as_position_independent_swizzle_tensor(sQ_persist);
+
+      // Q+SFA TMA is issued by load warp 8 into sQ_persist and smem_sfa_ptr.
+      // Math waits q_ready, loads Q/SFA into registers, then releases q_empty.
+      wait_mbar_parity(q_ready_mbar_ptr, (uint32_t)q_tma_parity);
+      q_tma_parity ^= 1;
+
+	      // Mask and RAB consumption are force-inlined helpers.  Their call sites
+	      // below now show the GEMM1 -> mask -> RAB -> activation handoff directly.
+
+      // SFP (unit scale for P) — separate buffer so real SFA SMEM stays valid for per-tile GEMM1 s2r.
+      for (int i = tidx_math; i < kBlockM; i += kNMathThreads)
+        smem_sfp_ptr[i] = 0x7f7f7f7f;
+
+      // ===== MATH WARP DOUBLE-BUFFER QMMA CONSUMER LOOP =====
+      // Phase 11: s2r V^T uses ldmatrix.m16n16.x2.trans.b8 (LDSM_T) directly from MN_SW128 SMEM.
+      // Under AtomLayout <_8,_1,_1>, all 8 warps load all 4 N-slabs (nw=0..3 outer loop);
+      // 16B alignment: d_start = nw*32+d_mat ∈ multiples of 16, XOR swizzle_xor also multiple of 16.
+      static_assert(kHeadDim % 32 == 0 && kBlockN % 16 == 0,
+          "LDSM_T requires kHeadDim divisible by 32 and kBlockN divisible by 16.");
+      // ── N-loop tile-invariants (Opt A): hoisted from per-tile load ───────────────────────
+      // Q (sQ_persist) and SFA are written by TMA before the loop (guaranteed visible after
+      // wait_mbar_parity at S2) and never change.  Hoisting eliminates 4 ldmatrix + 1 LDS
+      // per N-tile.
+      // NOTE: tCrSFP is NOT hoisted — smem_sfp_ptr is written by distributed thread writes
+      // (not TMA) and requires the long per-tile gap (mbarrier wait + GEMM1, ~500 cycles)
+      // to guarantee visibility.  Hoisting would introduce a race with no explicit barrier.
+      Tensor tCrSFA = BS1::partition_fragment_SFA(sSFA(_,_,_0{}), thr_mma_g1);
+      const int warp_m  = tidx_math / 32;
+      const int lane    = tidx_math & 31;
+      const int q_mat_num = lane >> 3;
+      const int q_mat_row = lane & 7;
+      const int q_m_abs = warp_m * 16 + ((q_mat_num & 1) << 3) + q_mat_row;
+      const int q_k_half = q_mat_num >> 1;
+      const int sfa_row = warp_m * 16 + 8 * (lane & 1) + (lane >> 2);
+      tCrSFA(0, 0, 0)  = smem_sfa_ptr[sfa_row];
+      auto tCrSFA_frg = BS1::transform_fragment_for_qmma(tCrSFA);
+      auto q_ldsm_atom = Copy_Atom<SM75_U32x4_LDSM_N, uint32_t>{};
+      auto sQ_persist_u128 = recast<uint128_t>(sQ_persist);
+
+      Tensor tCrQ = thr_mma_g1.partition_fragment_A(sQ_persist_pi);
+      if constexpr (kHeadDim <= 128) {
+        clear(tCrQ);
+        constexpr int kQBlockCount = kHeadDim / 32;
+        auto tXrQ = recast<uint32_t>(tCrQ);
+        const int q_src_offset = sQ_persist_u128.layout()(q_m_abs, q_k_half);
+        Tensor tXsQ = make_tensor(
+            sQ_persist_u128.data() + q_src_offset,
+            cute::Layout<Shape<_1, Int<kQBlockCount>>, Stride<_0, _2>>{});
+        Tensor tXrQ_copy = make_tensor(
+            tXrQ.data(),
+            cute::Layout<Shape<_4, Int<kQBlockCount>>, Stride<_1, _4>>{});
+        cute::copy(q_ldsm_atom, tXsQ, tXrQ_copy);
+      }
+      if constexpr (kHeadDim <= 128) {
+        if ((tidx_math & 31) == 0) {
+          arrive_mbar(q_empty_mbar_ptr);
+        }
+      }
+
+      // Per-tile lambda (Opt C): instantiated with kIsMasking=true (Phase 1, causal diagonal)
+      // and kIsMasking=false (Phase 2, steady-state unmasked) to allow compile-time dead-code
+      // elimination of apply_mask_bs in the hot path.  n_valid_ref is modified in-place by
+      // the is_jump adjustment; math_stage persists across tiles and flips after every N tile.
+      constexpr bool kStoreOInMainloop =
+          kHeadDim <= 128 &&
+          Is_causal && !Is_target && !Is_context && !Is_arbitrary && !Is_local;
+      bool o_epilogue_done = false;
+      auto store_o_epilogue = [&]() {
+        for (int i = 0; i < size(acc_o); ++i) acc_o(i) /= params.scaling_seqlen;
+        using OutElement = typename Kernel_traits::OutputType;
+        Tensor rO = make_tensor_like<OutElement>(acc_o);
+        flash::convert_type_safe(acc_o, rO);
+
+        if constexpr (!Kernel_traits::kUseTmaOStore) {
+          Tensor cO_id = make_identity_tensor(Shape<Int<kBlockM>, Int<kHeadDimGemm2>>{});
+          Tensor tOcO = thr_mma_g2.partition_C(cO_id);
+          OutElement* gO_ptr = reinterpret_cast<OutElement*>(params.o_ptr)
+              + binfo.q_offset(params.o_row_stride)
+              + bidh * params.o_head_stride;
+          const int valid_rows = actual_seqlen_q - m_block * kBlockM;
+          CUTE_UNROLL
+          for (int flat = 0; flat < size(rO); ++flat) {
+            const auto coord = tOcO(flat);
+            const int m_rel = int(get<0>(coord));
+            const int n_pos = int(get<1>(coord));
+            if (m_rel < valid_rows && n_pos < kHeadDim) {
+              gO_ptr[(m_block * kBlockM + m_rel) * params.o_row_stride + n_pos] = rO(flat);
+            }
+          }
+        } else {
+          static_assert(
+              Kernel_traits::kSmemWsOStoreBytes >= kBlockM * kHeadDim * (int)sizeof(OutElement),
+              "O SMEM buffer is too small.");
+          if constexpr (Kernel_traits::kUseAliasedOBuffer) {
+            // The aliased D256 path writes O over the KV staging region.  All math
+            // warps must finish consuming V before any warp starts STSM into it.
+            asm volatile("bar.sync 1, 256;\n" : : : "memory");
+          }
+          char* smem_o = reinterpret_cast<char*>(smem_) +
+              (Kernel_traits::kUseAliasedOBuffer ? 0 : Kernel_traits::kSmemWsOOffset);
+
+          // Wait until the O buffer is no longer owned by the previous TMA store.
+          wait_mbar_parity(
+              smem_base32 + (uint32_t)kSmemMbar0Offset + 96u,
+              (uint32_t)o_empty_wait_parity);
+          o_empty_wait_parity ^= 1;
+          Tensor sO_tma = make_tensor(
+              make_smem_ptr(reinterpret_cast<OutElement*>(smem_o)),
+              typename Kernel_traits::SmemLayoutWsO_TMA{});
+          auto sO_swz = as_position_independent_swizzle_tensor(sO_tma);
+          {
+            // STSM writes the same swizzled SMEM layout consumed by O TMA store.
+            static_assert(sizeof(OutElement) == 2, "stmatrix.m8n8.b16 requires 2-byte elements");
+            static_assert(kHeadDim <= 256, "O STSM path currently supports D32/D64/D128/D256");
+
+            auto rO_u32 = recast<uint32_t>(rO);
+            auto sO_u128 = recast<uint128_t>(sO_swz);
+            auto stsm_atom = Copy_Atom<SM90_U32x4_STSM_N, uint32_t>{};
+            constexpr int kOStsmNGroups = kHeadDim / 32;
+
+            const int lane        = tidx_math & 31;
+            const int lq          = lane >> 2;   // lane-quad (0..7): selects data row within 8x8 matrix
+            const int lqt         = lane & 3;    // lane-quad-thread (0..3): selects data col-group
+            const int warp_m      = tidx_math >> 5;  // M-warp index (0..7)
+            const int addr_row    = ((lq & 1) << 2) | lqt;  // STSM address-row within matrix (0..7)
+            const int mat_in_lane = lq >> 1;                 // which of 4 matrices this thread addresses
+
+            CUTE_UNROLL
+            for (int m_grp = 0; m_grp < 2; ++m_grp) {
+              const int row = warp_m * 16 + m_grp * 8 + addr_row;
+
+              CUTE_UNROLL
+              for (int n_grp = 0; n_grp < kOStsmNGroups; ++n_grp) {
+                // This thread addresses row addr_row of matrix mat_in_lane,
+                // starting at N-column (n_grp*32 + mat_in_lane*8).
+                const int col = n_grp * 32 + mat_in_lane * 8;
+
+                int j0, j1, j2, j3;
+                if constexpr (kHeadDimGemm2 == 64) {
+                  // BS2 D32/D64 uses linear 64-wide N atom order: 0,8,16,...,56.
+                  j0 = 4 * n_grp + 0;
+                  j1 = 4 * n_grp + 1;
+                  j2 = 4 * n_grp + 2;
+                  j3 = 4 * n_grp + 3;
+                } else if constexpr (kHeadDimGemm2 == 128) {
+                  // BS2 D128 uses PermMmaTileN <_8,_4,_4>:<_1,_32,_8>.
+                  j0 = n_grp;
+                  j1 = n_grp + kOStsmNGroups;
+                  j2 = n_grp + 2 * kOStsmNGroups;
+                  j3 = n_grp + 3 * kOStsmNGroups;
+                } else {
+                  // D256 is two D128 slabs in C-fragment order.
+                  const int slab = n_grp >> 2;
+                  const int grp = n_grp & 3;
+                  const int base = slab * 16 + grp;
+                  j0 = base;
+                  j1 = base + 4;
+                  j2 = base + 8;
+                  j3 = base + 12;
+                }
+                Tensor tXsO = make_tensor(
+                    sO_u128.data() + sO_u128.layout()(row, col / 8),
+                    Layout<_1>{});
+                if constexpr (kHeadDimGemm2 == 64) {
+                  Tensor tXrO = make_tensor(
+                      rO_u32.data() + 2 * j0 + m_grp,
+                      Layout<Shape<_4>, Stride<_2>>{});
+                  cute::copy(stsm_atom, tXrO, tXsO);
+                } else {
+                  static_assert(
+                      2 * (4) == 8,
+                      "D128/D256 STSM source order expects 8-u32 stride.");
+                  Tensor tXrO = make_tensor(
+                      rO_u32.data() + 2 * j0 + m_grp,
+                      Layout<Shape<_4>, Stride<_8>>{});
+                  cute::copy(stsm_atom, tXrO, tXsO);
+                }
+              }
+            }
+          }
+
+          // For partial tiles (last tile of a varlen sequence): zero SMEM rows [valid_rows, kBlockM)
+          // so TMA bulk store does not write garbage to GMEM beyond actual_seqlen_q.
+          const int valid_rows = actual_seqlen_q - m_block * kBlockM;
+          if (valid_rows < kBlockM) {
+            // Ensure all STSM stores are complete before any warp zeros OOB rows.
+            // Full tiles skip this: o_ready is initialized with count=8, so the O-store warp
+            // cannot proceed until each math warp has arrived after its own STSM stores.
+            asm volatile("bar.sync 1, 256;\n" : : : "memory");
+            const int oob_elems = (kBlockM - valid_rows) * kHeadDim;
+            for (int i = tidx_math; i < oob_elems; i += kNMathThreads) {
+              const int row_offset = i / kHeadDim;
+              const int row = valid_rows + row_offset;
+              const int col = i - row_offset * kHeadDim;
+              sO_swz(row, col) = OutElement(0);
+            }
+            asm volatile("bar.sync 1, 256;\n" : : : "memory");  // OOB zeros visible before TMA.
+          }
+
+          // Produce o_ready[0]. O-store warp owns the TMA store and releases
+          // o_empty[0] after the store completes.
+          if ((tidx_math & 31) == 0) {
+            const uint32_t o_ready_addr =
+                smem_base32 + (uint32_t)kSmemMbar0Offset + 80u;
+            arrive_mbar(o_ready_addr);
+          }
+        }
+      };
+
+      auto run_n_tile = [&](int nb, int n_valid_ref, int masking_step, bool do_mask_runtime,
+                            bool store_o_after, auto kMaskMode_c) {
+        constexpr int kMaskMode = decltype(kMaskMode_c)::value;
+        constexpr bool kIsMasking = kMaskMode == 1;
+        constexpr bool kRuntimeMasking = kMaskMode == 2;
+
+        // Stage-dependent SMEM pointers — pure pointer arithmetic, no TMA dependency.
+        int32_t* smem_sfb_cur = smem_sfa_ptr + 2 * kBlockM + math_stage * kBlockN;
+        FP8Elem* sK_cur  = reinterpret_cast<FP8Elem*>(smem_q) + math_stage * 2 * kSmemKVElems;
+        FP8Elem* sVt_cur = reinterpret_cast<FP8Elem*>(smem_q) + kSmemKVElems + math_stage * 2 * kSmemKVElems;
+
+        // GEMM1 only needs K/SFB. Wait V/SFV later, right before GEMM2.
+        {
+          const int cur_parity = math_stage ? tma_parity1 : tma_parity0;
+          uint32_t kaddr = smem_base32 + (uint32_t)kSmemMbar0Offset + (uint32_t)(math_stage * 8);
+          wait_mbar_parity(kaddr, (uint32_t)cur_parity);
+        }
+        // mbarrier.test_wait already guarantees K/SFB data visibility in SMEM.
+        // K and V have separate empty counters: K is released after K/SFB s2r,
+        // V is waited/released later around V/SFV s2r.
+        asm volatile("" ::: "memory");
+
+        Tensor sSFB_ = make_tensor(make_smem_ptr(smem_sfb_cur), SmemLayoutSFB{});
+        auto sSFB = as_position_independent_swizzle_tensor(sSFB_);
+
+        // GEMM1: acc_s += Q × K^T (block-scaled QMMA).
+        // Full-K=128 copy: make_tiled_copy_A/B expects the full TiledMMA tile;
+        // cute::gemm internally loops 4×K=32 when the fragment covers K=128.
+        Tensor acc_s = partition_fragment_C(tiled_mma_g1, Shape<Int<kBlockM>, Int<kBlockN>>{});
+        clear(acc_s);
+
+        Tensor tCrSFB = BS1::partition_fragment_SFB(sSFB(_,_,_0{}), thr_mma_g1);
+        {
+          // get_layoutSFB_TV degenerates under <_8,_1,_1>: ThrN=1 causes all threads to map
+          // to SMEM position 0 via the stride-0 btile, leaving tCrSFB[1..15] uninitialized.
+          // Direct load from smem_sfb_ptr (LINEAR N-row order [0..kBlockN-1]).
+          // partition_fragment_SFB->make_fragment_like compacts the (4,4) N-rep sub-modes in
+          // column-major order (first dim fastest), giving fragment nr -> N_base = 8*nr (LINEAR).
+          // n_row_sfb: this thread's N-offset within the 8-wide N-atom (lane >> 2 = 0..7).
+          const int n_row_sfb = (tidx_math & 31) >> 2;
+          constexpr int kNAtomsSFB = kBlockN / 8;
+          CUTE_UNROLL
+          for (int nr = 0; nr < kNAtomsSFB; ++nr) {
+            const int N_base = nr * 8;  // LINEAR: 0, 8, 16, ..., 120
+            tCrSFB(0, nr, 0) = smem_sfb_cur[N_base + n_row_sfb];
+          }
+        }
+        if constexpr (kHeadDim <= 128) {
+          auto sK_cur_pi = as_position_independent_swizzle_tensor(
+              make_tensor(make_smem_ptr(sK_cur), SmemLayoutK_SW128{}));
+          auto tCrSFB_frg = BS1::transform_fragment_for_qmma(tCrSFB);
+          Tensor tCrK = thr_mma_g1.partition_fragment_B(sK_cur_pi);
+          clear(tCrK);
+          // GEMM1: tCrQ and tCrSFA_frg are N-loop invariants hoisted above the loop.
+          auto tXsK = s2r_thr_B_g1.partition_S(sK_cur_pi);
+          auto tXrK = s2r_thr_B_g1.retile_D(tCrK);
+          cute::copy(s2r_copy_B_g1, tXsK, tXrK);
+          if ((tidx_math & 31) == 0) {
+            uint32_t k_empty_addr =
+                smem_base32 + (uint32_t)kSmemMbar0Offset + 32u + (uint32_t)(math_stage * 8);
+            arrive_mbar(k_empty_addr);
+          }
+          cute::gemm(tiled_mma_g1,
+              make_zip_tensor(tCrQ, tCrSFA_frg(_,_,_,_0{})),
+              make_zip_tensor(tCrK, tCrSFB_frg(_,_,_,_0{})),
+              acc_s);
+        } else if constexpr (kHeadDim == 256) {
+          using SmemLayoutQChunk_SW128 = decltype(tile_to_shape(
+              GMMA::Layout_K_SW128_Atom<FP8Elem>{},
+              Shape<Int<kBlockM>, Int<128>>{}));
+          FP8Elem* q_persist_base = reinterpret_cast<FP8Elem*>(
+              reinterpret_cast<char*>(smem_) + Kernel_traits::kSmemWsQPersistOffset);
+
+          {
+            Tensor tCrSFA0 = make_tensor_like<int32_t>(tCrSFA);
+            Tensor tCrSFB0 = make_tensor_like<int32_t>(tCrSFB);
+            CUTE_UNROLL
+            for (int i = 0; i < size(tCrSFA); ++i) {
+              tCrSFA0(i) = hstu_ws_replicate_e8m0_lane(tCrSFA(i), 0);
+            }
+            CUTE_UNROLL
+            for (int i = 0; i < size(tCrSFB); ++i) {
+              tCrSFB0(i) = hstu_ws_replicate_e8m0_lane(tCrSFB(i), 0);
+            }
+            auto tCrSFA0_frg = BS1::transform_fragment_for_qmma(tCrSFA0);
+            auto tCrSFB0_frg = BS1::transform_fragment_for_qmma(tCrSFB0);
+
+            Tensor sQ_chunk0 = make_tensor(
+                make_smem_ptr(q_persist_base),
+                SmemLayoutQChunk_SW128{});
+            auto sQ_chunk0_pi = as_position_independent_swizzle_tensor(sQ_chunk0);
+            Tensor tCrQ0 = thr_mma_g1.partition_fragment_A(sQ_chunk0_pi);
+            clear(tCrQ0);
+            auto tXrQ0 = recast<uint32_t>(tCrQ0);
+            const int q_src_offset0 = sQ_persist_u128.layout()(q_m_abs, q_k_half);
+            Tensor tXsQ0 = make_tensor(
+                sQ_persist_u128.data() + q_src_offset0,
+                cute::Layout<Shape<_1, _4>, Stride<_0, _2>>{});
+            Tensor tXrQ0_copy = make_tensor(
+                tXrQ0.data(),
+                cute::Layout<Shape<_4, _4>, Stride<_1, _4>>{});
+            cute::copy(q_ldsm_atom, tXsQ0, tXrQ0_copy);
+
+            Tensor sK_full = make_tensor(
+                make_smem_ptr(sK_cur),
+                SmemLayoutK_SW128{});
+            Tensor sK_chunk0 = local_tile(
+                sK_full,
+                Shape<Int<kBlockN>, Int<128>>{},
+                make_coord(0, 0));
+            auto sK_chunk0_pi = as_position_independent_swizzle_tensor(sK_chunk0);
+            Tensor tCrK0 = thr_mma_g1.partition_fragment_B(sK_chunk0_pi);
+            clear(tCrK0);
+            auto tXsK0 = s2r_thr_B_g1.partition_S(sK_chunk0_pi);
+            auto tXrK0 = s2r_thr_B_g1.retile_D(tCrK0);
+            cute::copy(s2r_copy_B_g1, tXsK0, tXrK0);
+
+            cute::gemm(tiled_mma_g1,
+                make_zip_tensor(tCrQ0, tCrSFA0_frg(_,_,_,_0{})),
+                make_zip_tensor(tCrK0, tCrSFB0_frg(_,_,_,_0{})),
+                acc_s);
+          }
+
+          {
+            Tensor tCrSFA1 = make_tensor_like<int32_t>(tCrSFA);
+            Tensor tCrSFB1 = make_tensor_like<int32_t>(tCrSFB);
+            CUTE_UNROLL
+            for (int i = 0; i < size(tCrSFA); ++i) {
+              tCrSFA1(i) = hstu_ws_replicate_e8m0_lane(tCrSFA(i), 1);
+            }
+            CUTE_UNROLL
+            for (int i = 0; i < size(tCrSFB); ++i) {
+              tCrSFB1(i) = hstu_ws_replicate_e8m0_lane(tCrSFB(i), 1);
+            }
+            auto tCrSFA1_frg = BS1::transform_fragment_for_qmma(tCrSFA1);
+            auto tCrSFB1_frg = BS1::transform_fragment_for_qmma(tCrSFB1);
+
+            Tensor sQ_chunk1 = make_tensor(
+                make_smem_ptr(q_persist_base),
+                SmemLayoutQChunk_SW128{});
+            auto sQ_chunk1_pi = as_position_independent_swizzle_tensor(sQ_chunk1);
+            Tensor tCrQ1 = thr_mma_g1.partition_fragment_A(sQ_chunk1_pi);
+            clear(tCrQ1);
+            auto tXrQ1 = recast<uint32_t>(tCrQ1);
+            const int q_src_offset1 = sQ_persist_u128.layout()(q_m_abs, 8 + q_k_half);
+            Tensor tXsQ1 = make_tensor(
+                sQ_persist_u128.data() + q_src_offset1,
+                cute::Layout<Shape<_1, _4>, Stride<_0, _2>>{});
+            Tensor tXrQ1_copy = make_tensor(
+                tXrQ1.data(),
+                cute::Layout<Shape<_4, _4>, Stride<_1, _4>>{});
+            cute::copy(q_ldsm_atom, tXsQ1, tXrQ1_copy);
+
+            Tensor sK_full = make_tensor(
+                make_smem_ptr(sK_cur),
+                SmemLayoutK_SW128{});
+            Tensor sK_chunk1 = local_tile(
+                sK_full,
+                Shape<Int<kBlockN>, Int<128>>{},
+                make_coord(0, 1));
+            auto sK_chunk1_pi = as_position_independent_swizzle_tensor(sK_chunk1);
+            Tensor tCrK1 = thr_mma_g1.partition_fragment_B(sK_chunk1_pi);
+            clear(tCrK1);
+            auto tXsK1 = s2r_thr_B_g1.partition_S(sK_chunk1_pi);
+            auto tXrK1 = s2r_thr_B_g1.retile_D(tCrK1);
+            cute::copy(s2r_copy_B_g1, tXsK1, tXrK1);
+
+            cute::gemm(tiled_mma_g1,
+                make_zip_tensor(tCrQ1, tCrSFA1_frg(_,_,_,_0{})),
+                make_zip_tensor(tCrK1, tCrSFB1_frg(_,_,_,_0{})),
+                acc_s);
+          }
+
+          if ((tidx_math & 31) == 0) {
+            uint32_t k_empty_addr =
+                smem_base32 + (uint32_t)kSmemMbar0Offset + 32u + (uint32_t)(math_stage * 8);
+            arrive_mbar(k_empty_addr);
+          }
+        }
+        constexpr bool kUseRabSkipMasked =
+            (Is_causal && !Is_context && !Is_target && !Is_local && !Is_arbitrary) ||
+            Is_local || Is_arbitrary || (Is_context && !Paged_KV) || (Is_target && Paged_KV);
+        if constexpr (!(Has_rab && kUseRabSkipMasked)) {
+          hstu_ws_consume_rab_bs<Kernel_traits>(
+              acc_s, nb, false, rab_ready_wait_parity0, smem_base32, tidx_math,
+              thr_mma_g1, sRab, m_block, actual_seqlen_q, actual_seqlen_k,
+              actual_seqlen_h, n_block_paged, last_page_offset);
+        } else if constexpr (Has_rab && Paged_KV && Is_target) {
+          hstu_ws_consume_rab_paged_target_bs<Kernel_traits>(
+              acc_s, rab_ready_wait_parity0, smem_base32, tidx_math,
+              thr_mma_g1, sRab);
+        }
+        // Masking (Opt C: compile-time specialized).  Most masked RAB paths
+        // apply the mask first so the SMEM add can skip -inf entries.  Paged
+        // target consumes RAB before masking to keep the hot path spill-free;
+        // the target/causal mask overwrites invalid entries below.
+        // kIsMasking=true  (Phase 1): always apply_mask_bs (causal diagonal or Is_arbitrary/Is_local).
+        // kIsMasking=false (Phase 2): steady-state; skip diagonal masking; varlen-end check only.
+        bool mask_applied = false;
+        if constexpr (Is_arbitrary || Is_local || kIsMasking) {
+          hstu_ws_apply_mask_bs<Kernel_traits, Target_group_size_1>(
+              acc_s, nb, params, thr_mma_g1, gMinFunc, gMaxFunc, m_block,
+              actual_seqlen_k, actual_seqlen_h, actual_seqlen_c,
+              actual_seqlen_offset, last_page_offset);
+          mask_applied = true;
+        } else if constexpr (kRuntimeMasking) {
+          if (do_mask_runtime) {
+            hstu_ws_apply_mask_bs<Kernel_traits, Target_group_size_1>(
+                acc_s, nb, params, thr_mma_g1, gMinFunc, gMaxFunc, m_block,
+                actual_seqlen_k, actual_seqlen_h, actual_seqlen_c,
+                actual_seqlen_offset, last_page_offset);
+            mask_applied = true;
+          } else {
+            if ((nb + 1) * kBlockN > actual_seqlen_h) {
+              hstu_ws_apply_mask_bs<Kernel_traits, Target_group_size_1>(
+                  acc_s, nb, params, thr_mma_g1, gMinFunc, gMaxFunc, m_block,
+                  actual_seqlen_k, actual_seqlen_h, actual_seqlen_c,
+                  actual_seqlen_offset, last_page_offset);
+              mask_applied = true;
+            }
+          }
+        } else {
+          if ((nb + 1) * kBlockN > actual_seqlen_h) {
+            hstu_ws_apply_mask_bs<Kernel_traits, Target_group_size_1>(
+                acc_s, nb, params, thr_mma_g1, gMinFunc, gMaxFunc, m_block,
+                actual_seqlen_k, actual_seqlen_h, actual_seqlen_c,
+                actual_seqlen_offset, last_page_offset);
+            mask_applied = true;
+          }
+        }
+        if constexpr (Has_rab && kUseRabSkipMasked) {
+          if constexpr (Paged_KV && Is_target) {
+            // Paged target consumed RAB before masking; invalid entries are
+            // overwritten by the target/causal mask.
+          } else {
+            hstu_ws_consume_rab_bs<Kernel_traits>(
+                acc_s, nb, mask_applied, rab_ready_wait_parity0, smem_base32, tidx_math,
+                thr_mma_g1, sRab, m_block, actual_seqlen_q, actual_seqlen_k,
+                actual_seqlen_h, n_block_paged, last_page_offset);
+          }
+        }
+        for (int i = 0; i < size(acc_s); ++i) acc_s(i) *= params.alpha;
+        fast_silu(acc_s);
+
+        // ── P pre-conversion: F32 → packed FP8 ───────────────────────────────
+        // Problem: during the P-write loop below, both acc_s (64 F32 = 64 regs)
+        // and acc_o (64 F32 = 64 regs) must be live, and the SW128 swizzle address
+        // LOP3 computation needs ~20 temp regs.  These overlap with acc_o's lower
+        // register range (R4–R23), causing the compiler to spill acc_o (10×STL.64 +
+        // 10×LDL.LU.64 = 20 local-memory accesses per loop iteration).
+        //
+        // Fix: pre-convert acc_s (64 F32) → acc_s_packed (16 uint32, 4 FP8/reg)
+        // BEFORE the bar.sync + P-write loop.  After this block acc_s is dead
+        // (last read is here), so its 64 registers are freed and available to the
+        // LOP3 address computation, eliminating the acc_o spill.
+        //
+        // Build GEMM2 A-fragment P directly in registers via warp shuffle.
+        // With AtomLayout <_8,_1,_1> (1 N-warp), all N-columns of P live in each
+        // warp's own registers — no cross-warp SMEM staging or bar.sync is needed.
+        // permute_acc_s_packed_to_tCrP packs acc_s in flat C-fragment order,
+        // then performs the C-fragment → A-fragment register permutation.
+        // sPbuf_pi is defined for partition_fragment_A shape inference only; sK_cur is
+        // not written and remains available for the load warp's next TMA fill.
+        auto sPbuf_pi = [&]() {
+          if constexpr (kBlockN == 64) {
+            using SmemLayoutP_SW64 = decltype(tile_to_shape(
+                GMMA::Layout_K_SW64_Atom<FP8Elem>{},
+                Shape<Int<kBlockM>, Int<kBlockN>>{}));
+            Tensor sPbuf = make_tensor(make_smem_ptr(sK_cur), SmemLayoutP_SW64{});
+            return as_position_independent_swizzle_tensor(sPbuf);
+          } else {
+            using SmemLayoutP_SW128 = decltype(tile_to_shape(
+                typename BS2::SmemLayoutAtomA{},
+                Shape<Int<kBlockM>, Int<kBlockN>>{}));
+            Tensor sPbuf = make_tensor(make_smem_ptr(sK_cur), SmemLayoutP_SW128{});
+            return as_position_independent_swizzle_tensor(sPbuf);
+          }
+        }();
+        Tensor tCrP = thr_mma_g2.partition_fragment_A(sPbuf_pi);
+        permute_acc_s_packed_to_tCrP<kBlockN, kHeadDim>(tCrP, acc_s, tidx_math);
+        // acc_s is now DEAD.
+
+        { // tCrV, tCrSFV, tCrSFP scoped here: compiler can reuse registers freed by tCrK/tCrSFB.
+          {
+            const int cur_parity = math_stage ? tma_parity1 : tma_parity0;
+            uint32_t vaddr =
+                smem_base32 + (uint32_t)kSmemMbar0Offset + 16u + (uint32_t)(math_stage * 8);
+            wait_mbar_parity(vaddr, (uint32_t)cur_parity);
+          }
+          if (math_stage) { tma_parity1 ^= 1; } else { tma_parity0 ^= 1; }
+          asm volatile("" ::: "memory");
+
+          // s2r V row-major — LDSM_T from K_SW128-swizzled SMEM [kBlockN, kHeadDim].
+          //
+          // SmemLayoutVt_SW128 = K_SW128 on [kBlockN, kHeadDim]:
+          //   physical_byte(n_k, d) = n_k * kHeadDim + (d ^ ((n_k & 7) << 4)).
+          //   TMA loads row-major V directly into this layout.
+          //
+          // LDSM_T (ldmatrix.sync.aligned.m16n16.x2.trans.shared.b8): transposes [16 n_k × 32 d]
+          // from SMEM into registers. Lane t provides address for n_k row (ni*16 + t%16),
+          // d_start = dg*32 + (t>>4)*16 (matrix 0 or 1). After transpose, thread t receives
+          // 16 n_k values at its specific d-column, split into 4 registers r0..r3.
+          //
+          // Fragment placement: PermMmaTileN = Layout<Shape<_8,_4,_4>, Stride<_1,_32,_8>>
+          //   maps d-group dg (d ∈ [dg*32,(dg+1)*32)) to N-atoms nr ∈ {dg, dg+4, dg+8, dg+12}.
+          //   ni maps to K-block kb=ni>>1, K-half k_h=ni&1.
+          //   base = 32*(ni>>1) + 2*dg + (ni&1):
+          //     r0 → slot base+0  (nr=dg,    k_h)
+          //     r1 → slot base+8  (nr=dg+4,  k_h)
+          //     r2 → slot base+16 (nr=dg+8,  k_h)
+          //     r3 → slot base+24 (nr=dg+12, k_h)
+          //   Covers all 128 uint32 slots (16 N-atoms × 4 K-blocks × 2 regs). ✓
+          auto sVt_ns = [&]() {
+            if constexpr (kBlockN == 64) {
+              using SmemLayoutVt_SW64 = decltype(tile_to_shape(
+                  GMMA::Layout_K_SW64_Atom<FP8Elem>{},
+                  Shape<Int<kHeadDimGemm2>, Int<kBlockN>>{}));
+              return make_tensor(make_smem_ptr(sVt_cur), SmemLayoutVt_SW64{});
+            } else {
+              using SmemLayoutVt_SW128 = decltype(tile_to_shape(
+                  typename BS2::SmemLayoutAtomB{},
+                  Shape<Int<kHeadDim>, Int<kBlockN>>{}));
+              return make_tensor(make_smem_ptr(sVt_cur), SmemLayoutVt_SW128{});
+            }
+          }();
+          Tensor tCrV = thr_mma_g2.partition_fragment_B(sVt_ns);
+          hstu_ws_load_v_ldsm_t<Kernel_traits, kBlockN, kHeadDim, kHeadDimGemm2>(
+              sVt_cur, tCrV, tidx_math);
+
+          // s2r SFP (unit scale) and SFV.
+          // tCrSFP is per-tile: smem_sfp_ptr is thread-written (not TMA); the mbarrier wait +
+          // GEMM1 above (~500 cycles) ensure all write-thread SFP commits are visible here.
+          Tensor tCrSFP = BS2::partition_fragment_SFA(sSFP(_,_,_0{}), thr_mma_g2);
+          {
+            auto tXsSFP = s2r_thr_SFP.partition_S(sSFP);
+            auto tXrSFP = s2r_thr_SFP.retile_D(tCrSFP);
+            cute::copy(s2r_copy_SFP, tXsSFP(_,_,_,_0{}), tXrSFP);
+          }
+          auto tCrSFP_frg = BS2::transform_fragment_for_qmma(tCrSFP);
+          int32_t* smem_sfv_cur = smem_sfa_ptr + 2 * kBlockM + 2 * kBlockN + math_stage * kBlockN;
+          Tensor sSFV_ = make_tensor(make_smem_ptr(smem_sfv_cur), SmemLayoutSFV{});
+          auto sSFV = as_position_independent_swizzle_tensor(sSFV_);
+          Tensor tCrSFV = BS2::partition_fragment_SFB(sSFV(_,_,_0{}), thr_mma_g2);
+          {
+            // SFV TMA loads one scale vector per K/V tile stage (kBlockN entries).
+            // GEMM2's B operand is V^T, so BS2 expects SFV across the head-dim N atoms.
+            // The HSTU FP8 path stores the same V scale across the tile entries; for BN64,
+            // reading nr*8 would run past the 64-entry stage. Broadcast a valid entry.
+            // AtomLayoutSFB_TV = (4,8):(0,1): lane>>2 indexes the within-atom N-column offset.
+            const int n_row_sfv = (tidx_math & 31) >> 2;
+            const int sfv = smem_sfv_cur[n_row_sfv];
+            constexpr int kNAtomsSFV = kHeadDimGemm2 / 8;
+            CUTE_UNROLL
+            for (int nr = 0; nr < kNAtomsSFV; ++nr) {
+              tCrSFV(0, nr, 0) = sfv;
+            }
+          }
+          auto tCrSFV_frg = BS2::transform_fragment_for_qmma(tCrSFV);
+
+          // Signal load warp: sVt[math_stage]/SFV consumed; V load warp may overwrite.
+          if ((tidx_math & 31) == 0) {
+            uint32_t v_empty_addr =
+                smem_base32 + (uint32_t)kSmemMbar0Offset + 48u + (uint32_t)(math_stage * 8);
+            arrive_mbar(v_empty_addr);
+          }
+
+          // GEMM2: acc_o += P × V^T (block-scaled, tCrSFP_frg hoisted).
+          cute::gemm(tiled_mma_g2,
+              make_zip_tensor(tCrP, tCrSFP_frg(_,_,_,_0{})),
+              make_zip_tensor(tCrV, tCrSFV_frg(_,_,_,_0{})),
+              acc_o);
+        } // tCrV, tCrSFV freed here.
+
+        // End-of-tile cleanup: is_jump adjustment and double-buffer flip.
+        if (is_jump && masking_step == n_masking_steps - 1)
+          n_valid_ref = std::min(n_valid_ref, n_block_history);
+        if constexpr (!Kernel_traits::kUseSingleKVStage) {
+          math_stage ^= 1;
+        }
+        if constexpr (kStoreOInMainloop) {
+          if (store_o_after) {
+            store_o_epilogue();
+            o_epilogue_done = true;
+          }
+        }
+        return n_valid_ref;
+      };  // end run_n_tile lambda
+
+      // N-loop (Opt C): for causal (not arbitrary, not local), split into masked Phase 1
+      // (n_masking_steps tiles) and unmasked Phase 2 (steady-state) to allow compile-time
+      // dead-code elimination of apply_mask_bs in the hot path.
+      if constexpr (Is_causal && !Is_arbitrary && !Is_local) {
+        if constexpr (kHeadDim == 256 && !Is_target && !Is_context) {
+          for (int n_valid = n_block_max - 1, masking_step = 0; n_valid >= n_block_min;
+               ++masking_step, --n_valid) {
+            n_valid = run_n_tile(n_valid, n_valid, masking_step,
+                masking_step < n_masking_steps,
+                false,
+                std::integral_constant<int, 2>{});
+          }
+        } else {
+          int n_valid    = n_block_max - 1;
+          int masking_step = 0;
+          // Phase 1: causal diagonal tiles — apply_mask_bs compiled in (kIsMasking=true).
+          for (; n_valid >= n_block_min && masking_step < n_masking_steps; ++masking_step, --n_valid)
+            n_valid = run_n_tile(n_valid, n_valid, masking_step,
+                false,
+                (!Is_target && !Is_context && n_valid == n_block_min),
+                std::integral_constant<int, 1>{});
+          // Phase 2: steady-state tiles — apply_mask_bs compile-time eliminated (kIsMasking=false).
+          for (; n_valid >= n_block_min; ++masking_step, --n_valid)
+            n_valid = run_n_tile(n_valid, n_valid, masking_step,
+                false,
+                (!Is_target && !Is_context && n_valid == n_block_min),
+                std::integral_constant<int, 0>{});
+        }
+      } else if constexpr (Is_arbitrary || Is_local) {
+        // Every tile needs masking: pass true_type so apply_mask_bs is always compiled in.
+        for (int n_valid = n_block_max - 1, masking_step = 0; n_valid >= n_block_min;
+             ++masking_step, --n_valid) {
+          const int nb = Is_arbitrary ? int(sValidBlockIds[n_valid]) : n_valid;
+          n_valid = run_n_tile(nb, n_valid, masking_step,
+              false, false, std::integral_constant<int, 1>{});
+        }
+      } else {
+        // Full attention (!Is_causal, !Is_arbitrary, !Is_local): varlen-end check only.
+        for (int n_valid = n_block_max - 1, masking_step = 0; n_valid >= n_block_min;
+             ++masking_step, --n_valid)
+          n_valid = run_n_tile(n_valid, n_valid, masking_step,
+              false, false, std::integral_constant<int, 0>{});
+      }
+
+      if constexpr (kHeadDim > 128) {
+        if ((tidx_math & 31) == 0) {
+          arrive_mbar(q_empty_mbar_ptr);
+        }
+      }
+
+      // Complex/full paths keep the post-loop epilogue fallback.
+      if constexpr (kStoreOInMainloop) {
+        if (!o_epilogue_done) {
+          store_o_epilogue();
+        }
+      } else {
+        store_o_epilogue();
+      }
+    };
+
+    // Static tile-id broadcast mirrors the load path exactly.
+    const bool head_shared_rab = Has_rab && params.h_rab == 1 && params.h > 1;
+    if constexpr (Use_paired_persistent) {
+      const int num_m_block_persistent = Use_actual_target_scheduler
+          ? num_m_block_scheduler
+          : num_m_block_capacity;
+      if constexpr (Use_actual_target_scheduler) {
+        const int pairs_per_bh = (num_m_block_persistent + 1) / 2;
+        const int total_tile_pairs_persistent =
+            pairs_per_bh * params.h * params.b;
+        #pragma unroll 1
+        for (int tile_pair = int(blockIdx.x); tile_pair < total_tile_pairs_persistent; tile_pair += int(gridDim.x)) {
+          const int pair_idx = tile_pair % pairs_per_bh;
+          const int bh = tile_pair / pairs_per_bh;
+          const int bidb = bh / params.h;
+          const int bidh = bh - bidb * params.h;
+          const int m_hi = num_m_block_persistent - 1 - pair_idx;
+          const int m_lo = pair_idx;
+
+          run_math_tile(bidb, bidh, m_hi);
+          if (m_lo != m_hi) {
+            run_math_tile(bidb, bidh, m_lo);
+          }
+        }
+      } else {
+        const int total_tiles_persistent = num_m_block_persistent * params.h * params.b;
+        const int total_tile_pairs_persistent = (total_tiles_persistent + 1) / 2;
+        #pragma unroll 1
+        for (int tile_pair = int(blockIdx.x); tile_pair < total_tile_pairs_persistent; tile_pair += int(gridDim.x)) {
+          const int paired_tile = total_tiles_persistent - 1 - tile_pair;
+          const int tiles_this_pair = paired_tile == tile_pair ? 1 : 2;
+
+          #pragma unroll 1
+          for (int pair_slot = 0; pair_slot < tiles_this_pair; ++pair_slot) {
+            const int tile = pair_slot == 0 ? tile_pair : paired_tile;
+            const HstuWsTileCoord coord =
+                hstu_ws_decode_tile(tile, num_m_block_persistent, params.h, head_shared_rab);
+            run_math_tile(coord.bidb, coord.bidh, coord.m_block);
+          }
+        }
+      }
+    } else if constexpr (Use_full_persistent) {
+      const int num_m_block_persistent = Use_actual_target_scheduler
+          ? num_m_block_scheduler
+          : num_m_block_capacity;
+      const int total_tiles_persistent = num_m_block_persistent * params.h * params.b;
+      #pragma unroll 1
+      for (int tile = int(blockIdx.x); tile < total_tiles_persistent; tile += int(gridDim.x)) {
+        const HstuWsTileCoord coord =
+            hstu_ws_decode_tile(tile, num_m_block_persistent, params.h, head_shared_rab);
+        run_math_tile(coord.bidb, coord.bidh, coord.m_block);
+      }
+    } else {
+      run_math_tile(bidb_arg, bidh_arg, m_block_arg);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename Kernel_traits, typename Params, bool Target_group_size_1 = false>
+__global__ void __launch_bounds__(Kernel_traits::kNThreads, 1)
+hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma(
+    __grid_constant__ Params const params) {
+  constexpr int kBlockM = Kernel_traits::kBlockM;
+  constexpr bool Use_full_persistent =
+      !Kernel_traits::Is_causal &&
+      !Kernel_traits::Is_target &&
+      !Kernel_traits::Is_context &&
+      !Kernel_traits::Is_local &&
+      !Kernel_traits::Is_arbitrary;
+  constexpr bool Use_paired_persistent =
+      Kernel_traits::Is_causal &&
+      !Kernel_traits::Is_context &&
+      !Kernel_traits::Is_local &&
+      !Kernel_traits::Is_arbitrary &&
+      (!Kernel_traits::Is_target || Kernel_traits::Paged_KV) &&
+      (Kernel_traits::kHeadDim <= 128 || (Kernel_traits::Paged_KV && !Kernel_traits::Has_rab));
+  constexpr bool Use_persistent = Use_full_persistent || Use_paired_persistent;
+
+  if constexpr (!Use_persistent) {
+    int m_block;
+    int bidh;
+    int bidb = blockIdx.z;
+    if constexpr (Kernel_traits::Has_rab) {
+      if (params.h_rab == 1 && params.h > 1) {
+        m_block = gridDim.y - blockIdx.y - 1;
+        bidh    = blockIdx.x;
+      } else {
+        m_block = gridDim.x - blockIdx.x - 1;
+        bidh    = blockIdx.y;
+      }
+    } else {
+      m_block = gridDim.x - blockIdx.x - 1;
+      bidh    = blockIdx.y;
+    }
+    hstu_compute_attn_1rowblock_blackwell_rtx_fp8_ws<
+        Kernel_traits,
+        false,
+        false,
+        Target_group_size_1>(params, bidb, bidh, m_block);
+    return;
+  }
+
+  hstu_compute_attn_1rowblock_blackwell_rtx_fp8_ws<
+      Kernel_traits,
+      Use_full_persistent,
+      Use_paired_persistent,
+      Target_group_size_1>(
+      params,
+      0,
+      0,
+      0);
+}
+
+template <typename Kernel_traits, typename Params, bool Target_group_size_1 = false>
+__global__ void __launch_bounds__(Kernel_traits::kNThreads, 1)
+hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma_target_persistent(
+    __grid_constant__ Params const params) {
+  static_assert(Kernel_traits::Is_target, "target persistent entry is target-only");
+  static_assert(!Kernel_traits::Paged_KV, "target persistent entry is non-paged-only");
+  static_assert(!Kernel_traits::Has_rab, "target persistent entry is no-RAB-only");
+
+  hstu_compute_attn_1rowblock_blackwell_rtx_fp8_ws<
+      Kernel_traits,
+      false,
+      true,
+      Target_group_size_1>(params, 0, 0, 0);
+}

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_fwd_kernel_launch.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_fwd_kernel_launch.h
@@ -1,0 +1,492 @@
+#pragma once
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_fp8.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <type_traits>
+
+#include <cutlass/numeric_conversion.h>
+
+#include <cute/arch/copy_sm90_tma.hpp>
+#include <cute/atom/copy_traits_sm75.hpp>
+#include <cute/atom/copy_traits_sm90.hpp>
+#include <cute/tensor.hpp>
+
+#include "block_info.h"
+#include "hstu.h"
+#include "kernel_traits.h"
+#include "static_switch.h"
+#include "blackwell_rtx_qmma_builder.h"
+#include "utils.h"
+
+template <typename TMA_Q_t, typename TMA_K_t, typename TMA_Vt_t,
+          typename TMA_SFA_t, typename TMA_SFB_t, typename TMA_SFV_t,
+          typename TMA_O_t, typename TMA_Rab_t>
+struct Hstu_fwd_params_fp8_ws_tma : public Hstu_fwd_params {
+    TMA_Q_t   tma_q;
+    TMA_K_t   tma_k;
+    TMA_Vt_t  tma_vt;
+    TMA_SFA_t tma_sfa;
+    TMA_SFB_t tma_sfb;
+    TMA_SFV_t tma_sfv;
+    TMA_O_t   tma_o;
+    TMA_Rab_t tma_rab;
+};
+
+template <typename TMA_Q_t, typename TMA_K_t, typename TMA_Vt_t,
+          typename TMA_SFA_t, typename TMA_SFB_t, typename TMA_SFV_t,
+          typename TMA_O_t, typename TMA_Rab_t,
+          typename TMA_KPage_t, typename TMA_VtPage_t>
+struct Hstu_fwd_params_fp8_ws_tma_paged
+    : public Hstu_fwd_params_fp8_ws_tma<
+          TMA_Q_t, TMA_K_t, TMA_Vt_t, TMA_SFA_t, TMA_SFB_t, TMA_SFV_t,
+          TMA_O_t, TMA_Rab_t> {
+    TMA_KPage_t  tma_k_page;
+    TMA_VtPage_t tma_vt_page;
+};
+
+namespace flash {
+using namespace cute;
+#include "hstu_fwd_kernel_fp8_ws.h"
+} // namespace flash
+
+template <
+    typename elem_type,
+    int kHeadDim,
+    int kBlockM,
+    int kBlockN,
+    int kNWarps,
+    bool Is_causal,
+    bool Is_target,
+    bool Is_context,
+    bool Is_local,
+    bool Is_arbitrary,
+    int kNFunc,
+    bool Has_rab,
+    bool Paged_KV = false,
+    bool Is_Q_in_regs = false,
+    bool Share_Q_K_smem = false>
+void run_hstu_fwd_blackwell_rtx_fp8_ws_tma_impl(Hstu_fwd_params& params, cudaStream_t stream) {
+  using Kernel_traits = Hstu_fwd_kernel_traits_blackwell_rtx_fp8_ws<
+      kHeadDim, kBlockM, kBlockN, kNWarps,
+      Is_causal, Is_target, Is_context, Is_local, Is_arbitrary, kNFunc, Has_rab,
+      Paged_KV, Is_Q_in_regs, Share_Q_K_smem, cutlass::half_t>;
+
+  using FP8Elem = typename Kernel_traits::Element;
+  using RabElement = cutlass::bfloat16_t;
+  using SmemLayoutQ_TMA  = typename Kernel_traits::SmemLayoutQ_TMA;
+  using SmemLayoutK_TMA  = typename Kernel_traits::SmemLayoutK_TMA;
+  using SmemLayoutVt_TMA = typename Kernel_traits::SmemLayoutVt_TMA;
+  using SmemLayoutRab_TMA = typename Kernel_traits::SmemLayoutRab_TMA;
+
+  auto tensor_Q_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<FP8Elem*>(params.q_ptr)),
+      cute::make_layout(
+          cute::make_shape(params.total_q, params.d, params.h),
+          cute::make_stride(params.q_row_stride, cute::_1{}, params.q_head_stride)));
+  auto tma_q = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_Q_full,
+      SmemLayoutQ_TMA{},
+      cute::make_shape(cute::Int<kBlockM>{}, cute::Int<kHeadDim>{}),
+      cute::_1{});
+
+  auto tensor_K_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<FP8Elem*>(params.k_ptr)),
+      cute::make_layout(
+          cute::make_shape(params.total_k, params.d, params.h_k),
+          cute::make_stride(params.k_row_stride, cute::_1{}, params.k_head_stride)));
+  auto tma_k = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_K_full,
+      SmemLayoutK_TMA{},
+      cute::make_shape(cute::Int<kBlockN>{}, cute::Int<kHeadDim>{}),
+      cute::_1{});
+
+  auto tensor_Vt_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<FP8Elem*>(params.v_ptr)),
+      cute::make_layout(
+          cute::make_shape(params.total_k, params.d, params.h_k),
+          cute::make_stride(params.v_row_stride, cute::_1{}, params.v_head_stride)));
+  auto tma_vt = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_Vt_full,
+      SmemLayoutVt_TMA{},
+      cute::make_shape(cute::Int<kBlockN>{}, cute::Int<kHeadDim>{}),
+      cute::_1{});
+
+  using SmemLayoutSFA_TMA_t = cute::Layout<cute::Shape<cute::Int<kBlockM>, cute::Int<1>>,
+                                           cute::Stride<cute::_1, cute::Int<kBlockM>>>;
+  TORCH_CHECK(params.sf_q_packed_ptr != nullptr,
+              "run_hstu_fwd_blackwell_rtx_fp8_ws_tma_impl: sf_q_packed_ptr must be non-null");
+  auto tensor_SFA_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<int32_t*>(params.sf_q_packed_ptr)),
+      cute::make_layout(
+          cute::make_shape((int64_t)params.q_block_descale_head_stride, cute::Int<1>{}, params.h),
+          cute::make_stride(cute::_1{}, (int64_t)params.q_block_descale_head_stride,
+                            (int64_t)params.q_block_descale_head_stride)));
+  auto tma_sfa = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_SFA_full,
+      SmemLayoutSFA_TMA_t{},
+      cute::make_shape(cute::Int<kBlockM>{}, cute::Int<1>{}),
+      cute::_1{});
+
+  using SmemLayoutSFB_TMA_t = cute::Layout<cute::Shape<cute::Int<kBlockN>, cute::Int<1>>,
+                                           cute::Stride<cute::_1, cute::Int<kBlockN>>>;
+  TORCH_CHECK(params.sf_k_packed_ptr != nullptr,
+              "run_hstu_fwd_blackwell_rtx_fp8_ws_tma_impl: sf_k_packed_ptr must be non-null");
+  auto tensor_SFB_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<int32_t*>(params.sf_k_packed_ptr)),
+      cute::make_layout(
+          cute::make_shape((int64_t)params.kv_block_descale_head_stride, cute::Int<1>{}, params.h_k),
+          cute::make_stride(cute::_1{}, (int64_t)params.kv_block_descale_head_stride,
+                            (int64_t)params.kv_block_descale_head_stride)));
+  auto tma_sfb = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_SFB_full,
+      SmemLayoutSFB_TMA_t{},
+      cute::make_shape(cute::Int<kBlockN>{}, cute::Int<1>{}),
+      cute::_1{});
+
+  using SmemLayoutSFV_TMA_t = cute::Layout<cute::Shape<cute::Int<kBlockN>, cute::Int<1>>,
+                                           cute::Stride<cute::_1, cute::Int<kBlockN>>>;
+  TORCH_CHECK(params.sf_v_packed_ptr != nullptr,
+              "run_hstu_fwd_blackwell_rtx_fp8_ws_tma_impl: sf_v_packed_ptr must be non-null");
+  auto tensor_SFV_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<int32_t*>(params.sf_v_packed_ptr)),
+      cute::make_layout(
+          cute::make_shape((int64_t)params.v_block_descale_head_stride, cute::Int<1>{}, params.h_k),
+          cute::make_stride(cute::_1{}, (int64_t)params.v_block_descale_head_stride,
+                            (int64_t)params.v_block_descale_head_stride)));
+  auto tma_sfv = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_SFV_full,
+      SmemLayoutSFV_TMA_t{},
+      cute::make_shape(cute::Int<kBlockN>{}, cute::Int<1>{}),
+      cute::_1{});
+
+  using OutElement = typename Kernel_traits::OutputType;
+  using SmemLayoutO_TMA_t = typename Kernel_traits::SmemLayoutWsO_TMA;
+  auto tensor_O_full = cute::make_tensor(
+      cute::make_gmem_ptr(static_cast<OutElement*>(params.o_ptr)),
+      cute::make_layout(
+          cute::make_shape(params.total_q, params.d, params.h),
+          cute::make_stride(params.o_row_stride, cute::_1{}, params.o_head_stride)));
+  auto tma_o = cute::make_tma_copy(
+      cute::SM90_TMA_STORE{},
+      tensor_O_full,
+      SmemLayoutO_TMA_t{},
+      cute::make_shape(cute::Int<kBlockM>{}, cute::Int<kHeadDim>{}),
+      cute::_1{});
+
+  RabElement* rab_base = Has_rab
+      ? static_cast<RabElement*>(params.rab_ptr)
+      : reinterpret_cast<RabElement*>(params.q_ptr);
+  const int64_t rab_dim0 = Has_rab ? (int64_t)params.seqlen_k_rounded : (int64_t)kBlockM;
+  const int64_t rab_dim1 = Has_rab ? (int64_t)params.seqlen_k_rounded : (int64_t)kBlockN;
+  const int64_t rab_heads = Has_rab ? (int64_t)params.h_rab : 1;
+  const int64_t rab_batch = Has_rab ? (int64_t)params.b : 1;
+  const int64_t rab_stride_m = Has_rab ? (int64_t)params.rab_seqlen_k_stride : (int64_t)kBlockN;
+  const int64_t rab_stride_h = Has_rab ? (int64_t)params.rab_seqlen_q_stride
+                                       : (int64_t)kBlockM * kBlockN;
+  const int64_t rab_stride_b = Has_rab ? (int64_t)params.rab_seqlen_qk_stride
+                                       : (int64_t)kBlockM * kBlockN;
+  auto tensor_Rab_full = cute::make_tensor(
+      cute::make_gmem_ptr(rab_base),
+      cute::make_layout(
+          cute::make_shape(rab_dim0, rab_dim1, rab_heads, rab_batch),
+          cute::make_stride(rab_stride_m, cute::_1{}, rab_stride_h, rab_stride_b)));
+  auto tma_rab = cute::make_tma_copy(
+      cute::SM90_TMA_LOAD{},
+      tensor_Rab_full,
+      SmemLayoutRab_TMA{}(cute::_, cute::_, cute::_0{}),
+      cute::make_shape(cute::Int<kBlockM>{}, cute::Int<kBlockN>{}),
+      cute::_1{});
+
+  using TMA_Q_t   = decltype(tma_q);
+  using TMA_K_t   = decltype(tma_k);
+  using TMA_Vt_t  = decltype(tma_vt);
+  using TMA_SFA_t = decltype(tma_sfa);
+  using TMA_SFB_t = decltype(tma_sfb);
+  using TMA_SFV_t = decltype(tma_sfv);
+  using TMA_O_t   = decltype(tma_o);
+  using TMA_Rab_t = decltype(tma_rab);
+
+  size_t smem_size = Kernel_traits::kSmemSize;
+  const int num_m_block = (params.seqlen_q + kBlockM - 1) / kBlockM;
+  const int total_tiles = num_m_block * params.h * params.b;
+  const int total_tile_pairs = (total_tiles + 1) / 2;
+  static constexpr bool Use_paired_persistent =
+      Is_causal &&
+      !Is_context &&
+      !Is_local &&
+      !Is_arbitrary &&
+      (!Is_target || Paged_KV) &&
+      (kHeadDim <= 128 || (Paged_KV && !Has_rab));
+  static constexpr bool Use_full_persistent =
+      !Is_causal && !Is_target && !Is_context && !Is_local && !Is_arbitrary;
+  static constexpr bool Use_persistent = Use_full_persistent || Use_paired_persistent;
+  const bool runtime_target_no_rab =
+      Is_target && !Paged_KV && !Has_rab;
+  const int uniform_actual_seqlen_q =
+      (params.b > 0 && params.total_q % params.b == 0)
+      ? params.total_q / params.b
+      : 0;
+  const bool runtime_target_actual_persistent =
+      runtime_target_no_rab &&
+      uniform_actual_seqlen_q > 0 &&
+      uniform_actual_seqlen_q < params.seqlen_q &&
+      params.b * params.h >= 8 &&
+      params.b * params.h < 128;
+  const bool runtime_target_full_persistent = false;
+  const bool runtime_use_paired_persistent =
+      Use_paired_persistent ||
+      (runtime_target_actual_persistent && !runtime_target_full_persistent);
+  const bool runtime_use_full_persistent =
+      Use_full_persistent || runtime_target_full_persistent;
+  const bool runtime_use_persistent =
+      runtime_use_full_persistent || runtime_use_paired_persistent;
+  const int runtime_num_m_block =
+      runtime_target_actual_persistent
+      ? (uniform_actual_seqlen_q + kBlockM - 1) / kBlockM
+      : num_m_block;
+  const int runtime_total_tiles = runtime_num_m_block * params.h * params.b;
+  const int runtime_total_tile_pairs =
+      ((runtime_num_m_block + 1) / 2) * params.h * params.b;
+  const int persistent_work_units =
+      runtime_use_paired_persistent ? runtime_total_tile_pairs : runtime_total_tiles;
+  int device = 0;
+  int sm_count = 0;
+  if (runtime_use_persistent) {
+    C10_CUDA_CHECK(cudaGetDevice(&device));
+    C10_CUDA_CHECK(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
+  }
+  dim3 grid = runtime_use_persistent
+      ? dim3(std::min(persistent_work_units, sm_count))
+      : (Has_rab && params.h_rab == 1 && params.h > 1
+          ? dim3(params.h, num_m_block, params.b)
+          : dim3(num_m_block, params.h, params.b));
+  static constexpr bool Can_use_target_group_size_1 =
+      kHeadDim > 128 &&
+      Is_causal &&
+      Is_target &&
+      !Is_context &&
+      !Is_local &&
+      !Is_arbitrary &&
+      ((!Has_rab && !Paged_KV) || (Has_rab && Paged_KV));
+  static constexpr bool Require_target_group_size_1 =
+      kHeadDim > 128 &&
+      Is_causal &&
+      Is_target &&
+      !Is_local &&
+      !Is_arbitrary &&
+      Has_rab &&
+      Paged_KV;
+
+  auto launch_tma_kernel = [&](auto& tma_params) {
+    using TmaParamsT = std::decay_t<decltype(tma_params)>;
+    if constexpr (Require_target_group_size_1) {
+      TORCH_CHECK(
+          params.target_group_size == 1,
+          "Blackwell RTX FP8 paged target+RAB path requires target_group_size == 1, got ",
+          params.target_group_size);
+      auto kernel =
+          &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma<Kernel_traits, TmaParamsT, true>;
+      if (smem_size >= 48 * 1024) {
+        static std::atomic<bool> smem_attr_set_g1_required{false};
+        if (!smem_attr_set_g1_required.load(std::memory_order_acquire)) {
+          C10_CUDA_CHECK(cudaFuncSetAttribute(
+              kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          smem_attr_set_g1_required.store(true, std::memory_order_release);
+        }
+      }
+      kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(tma_params);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    } else {
+      if constexpr (Can_use_target_group_size_1) {
+        if (params.target_group_size == 1) {
+          if constexpr (Is_target && !Paged_KV && !Has_rab) {
+            auto kernel = runtime_target_actual_persistent
+                ? &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma_target_persistent<
+                      Kernel_traits, TmaParamsT, true>
+                : &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma<
+                      Kernel_traits, TmaParamsT, true>;
+            if (smem_size >= 48 * 1024) {
+              static std::atomic<bool> smem_attr_set_g1{false};
+              static std::atomic<bool> smem_attr_set_g1_target_persistent{false};
+              std::atomic<bool>& smem_attr_set_current =
+                  runtime_target_actual_persistent
+                  ? smem_attr_set_g1_target_persistent
+                  : smem_attr_set_g1;
+              if (!smem_attr_set_current.load(std::memory_order_acquire)) {
+                C10_CUDA_CHECK(cudaFuncSetAttribute(
+                    kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                smem_attr_set_current.store(true, std::memory_order_release);
+              }
+            }
+            kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(tma_params);
+          } else {
+            auto kernel =
+                &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma<Kernel_traits, TmaParamsT, true>;
+            if (smem_size >= 48 * 1024) {
+              static std::atomic<bool> smem_attr_set_g1{false};
+              if (!smem_attr_set_g1.load(std::memory_order_acquire)) {
+                C10_CUDA_CHECK(cudaFuncSetAttribute(
+                    kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                smem_attr_set_g1.store(true, std::memory_order_release);
+              }
+            }
+            kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(tma_params);
+          }
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+          return;
+        }
+      }
+      if constexpr (Is_target && !Paged_KV && !Has_rab) {
+        auto kernel = runtime_target_actual_persistent
+            ? &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma_target_persistent<
+                  Kernel_traits, TmaParamsT, false>
+            : &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma<
+                  Kernel_traits, TmaParamsT, false>;
+        if (smem_size >= 48 * 1024) {
+          static std::atomic<bool> smem_attr_set{false};
+          static std::atomic<bool> smem_attr_set_target_persistent{false};
+          std::atomic<bool>& smem_attr_set_current =
+              runtime_target_actual_persistent
+              ? smem_attr_set_target_persistent
+              : smem_attr_set;
+          if (!smem_attr_set_current.load(std::memory_order_acquire)) {
+            C10_CUDA_CHECK(cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            smem_attr_set_current.store(true, std::memory_order_release);
+          }
+        }
+        kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(tma_params);
+      } else {
+        auto kernel =
+            &flash::hstu_fwd_kernel_blackwell_rtx_fp8_ws_tma<Kernel_traits, TmaParamsT, false>;
+        if (smem_size >= 48 * 1024) {
+          static std::atomic<bool> smem_attr_set{false};
+          if (!smem_attr_set.load(std::memory_order_acquire)) {
+            C10_CUDA_CHECK(cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            smem_attr_set.store(true, std::memory_order_release);
+          }
+        }
+        kernel<<<grid, Kernel_traits::kNThreads, smem_size, stream>>>(tma_params);
+      }
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
+  };
+
+  if constexpr (Paged_KV) {
+    auto tensor_K_page = cute::make_tensor(
+        cute::make_gmem_ptr(static_cast<FP8Elem*>(params.kv_cache_ptr)),
+        cute::make_layout(
+            cute::make_shape(params.page_size, params.d, params.h_k, params.total_pages),
+            cute::make_stride(
+                params.kv_cache_head_stride, cute::_1{},
+                params.kv_cache_row_stride, params.kv_cache_kvtensor_stride)));
+    auto tma_k_page = cute::make_tma_copy(
+        cute::SM90_TMA_LOAD{},
+        tensor_K_page,
+        SmemLayoutK_TMA{},
+        cute::make_shape(cute::Int<kBlockN>{}, cute::Int<kHeadDim>{}),
+        cute::_1{});
+    auto tensor_Vt_page = cute::make_tensor(
+        cute::make_gmem_ptr(static_cast<FP8Elem*>(params.kv_cache_ptr) + params.kv_cache_page_stride),
+        cute::make_layout(
+            cute::make_shape(params.page_size, params.d, params.h_k, params.total_pages),
+            cute::make_stride(
+                params.kv_cache_head_stride, cute::_1{},
+                params.kv_cache_row_stride, params.kv_cache_kvtensor_stride)));
+    auto tma_vt_page = cute::make_tma_copy(
+        cute::SM90_TMA_LOAD{},
+        tensor_Vt_page,
+        SmemLayoutVt_TMA{},
+        cute::make_shape(cute::Int<kBlockN>{}, cute::Int<kHeadDim>{}),
+        cute::_1{});
+
+    using TMA_KPage_t  = decltype(tma_k_page);
+    using TMA_VtPage_t = decltype(tma_vt_page);
+    Hstu_fwd_params_fp8_ws_tma_paged<
+        TMA_Q_t, TMA_K_t, TMA_Vt_t, TMA_SFA_t, TMA_SFB_t, TMA_SFV_t, TMA_O_t,
+        TMA_Rab_t, TMA_KPage_t, TMA_VtPage_t> tma_params;
+    static_cast<Hstu_fwd_params&>(tma_params) = params;
+    tma_params.tma_q   = tma_q;
+    tma_params.tma_k   = tma_k;
+    tma_params.tma_vt  = tma_vt;
+    tma_params.tma_sfa = tma_sfa;
+    tma_params.tma_sfb = tma_sfb;
+    tma_params.tma_sfv = tma_sfv;
+    tma_params.tma_o   = tma_o;
+    tma_params.tma_rab = tma_rab;
+    tma_params.tma_k_page = tma_k_page;
+    tma_params.tma_vt_page = tma_vt_page;
+    launch_tma_kernel(tma_params);
+  } else {
+    Hstu_fwd_params_fp8_ws_tma<
+        TMA_Q_t, TMA_K_t, TMA_Vt_t, TMA_SFA_t, TMA_SFB_t, TMA_SFV_t, TMA_O_t,
+        TMA_Rab_t> tma_params;
+    static_cast<Hstu_fwd_params&>(tma_params) = params;
+    tma_params.tma_q   = tma_q;
+    tma_params.tma_k   = tma_k;
+    tma_params.tma_vt  = tma_vt;
+    tma_params.tma_sfa = tma_sfa;
+    tma_params.tma_sfb = tma_sfb;
+    tma_params.tma_sfv = tma_sfv;
+    tma_params.tma_o   = tma_o;
+    tma_params.tma_rab = tma_rab;
+    launch_tma_kernel(tma_params);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+    int Arch,
+    typename elem_type,
+    int kHeadDim,
+    bool Has_rab,
+    bool Is_local,
+    bool Is_causal,
+    bool Is_context,
+    bool Is_target,
+    bool Is_arbitrary,
+    int kNFunc>
+void run_hstu_fwd_(Hstu_fwd_params& params, cudaStream_t stream) {
+  constexpr bool Is_fp8_type = std::is_same_v<elem_type, cutlass::float_e4m3_t>;
+  static_assert(Is_fp8_type, "Blackwell RTX build only supports FP8 e4m3 forward.");
+
+  static constexpr auto tile_size =
+      flash::get_tile_size_fwd_blackwell_rtx<kHeadDim, Has_rab, Is_fp8_type, Is_arbitrary>();
+  static constexpr int kBlockM = std::get<0>(tile_size);
+  static constexpr int kBlockN = std::get<1>(tile_size);
+  static constexpr int kNWarps = std::get<2>(tile_size);
+  static constexpr bool Is_Q_in_regs = kHeadDim <= 128;
+  static constexpr bool Share_Q_K_smem = kHeadDim <= 128;
+
+  if constexpr (Is_fp8_type) {
+    static_assert(
+        kBlockN == 64,
+        "Blackwell RTX FP8 forward now routes through the WS TMA path, which expects kBlockN=64.");
+    BOOL_SWITCH(params.is_paged_kv, Paged_KV, [&] {
+      if constexpr (Paged_KV) {
+        TORCH_CHECK(
+            params.page_size == kBlockN,
+            "Blackwell RTX FP8 paged KV WS path requires page_size == kBlockN, got page_size=",
+            params.page_size,
+            ", kBlockN=",
+            kBlockN);
+      }
+      run_hstu_fwd_blackwell_rtx_fp8_ws_tma_impl<
+          elem_type, kHeadDim, kBlockM, kBlockN, kNWarps,
+          Is_causal, Is_target, Is_context, Is_local, Is_arbitrary, kNFunc, Has_rab,
+          Paged_KV, Is_Q_in_regs, Share_Q_K_smem>(params, stream);
+    });
+  }
+}

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_fwd_launch_template.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_fwd_launch_template.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Blackwell RTX HSTU forward launch template.
+// Instantiation point for run_hstu_fwd_<Arch, T, Hdim, ...>.
+
+#pragma once
+
+#include "hstu_fwd_kernel_launch.h"

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_ops_gpu.cpp
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/hstu_ops_gpu.cpp
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Blackwell RTX HSTU forward attention ops.
+// Registered as the hstu_varlen_fwd_120 operator.
+// Supports Blackwell RTX FP8 (quant_mode >= 0) forward pass.
+
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+#include <torch/nn/functional.h>
+
+#include <optional>
+
+#include "hstu.h"
+#include "static_switch.h"
+
+namespace fbgemm_gpu::hstu {
+
+#define CHECK_DEVICE(x) TORCH_CHECK(x.is_cuda(), #x " must be on CUDA")
+#define CHECK_SHAPE(x, ...)                           \
+  TORCH_CHECK(                                        \
+      x.sizes() == torch::IntArrayRef({__VA_ARGS__}), \
+      #x " must have shape (" #__VA_ARGS__ ")")
+#define CHECK_CONTIGUOUS(x) \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void set_params_fprop_blackwell_rtx(
+    Hstu_fwd_params* params,
+    const size_t b,
+    const size_t seqlen_q,
+    const size_t seqlen_k,
+    const size_t scaling_seqlen,
+    const size_t target_group_size,
+    const size_t seqlen_q_rounded,
+    const size_t seqlen_k_rounded,
+    const size_t h,
+    const size_t h_k,
+    const size_t h_rab,
+    const size_t d,
+    const float alpha,
+    const at::Tensor q,
+    const at::Tensor k,
+    const at::Tensor v,
+    const at::Tensor rab,
+    const std::optional<at::Tensor>& kv_cache,
+    at::Tensor out,
+    void* num_contexts_d,
+    void* cu_seqlens_q_d,
+    void* cu_seqlens_k_d,
+    void* seqused_q_d,
+    void* seqused_k_d,
+    void* page_offsets,
+    void* page_ids,
+    void* last_page_lens,
+    void* num_targets_d,
+    bool has_rab,
+    bool is_paged_kv,
+    int quant_mode,
+    const std::optional<at::Tensor>& func,
+    int window_size_left,
+    int window_size_right,
+    // FP8 descale factors (optional, required when quant_mode >= 0)
+    const std::optional<at::Tensor>& descale_q,
+    const std::optional<at::Tensor>& descale_k,
+    const std::optional<at::Tensor>& descale_v) {
+  *params = {};
+
+  params->arch = at::cuda::getCurrentDeviceProperties()->major * 10 +
+      at::cuda::getCurrentDeviceProperties()->minor;
+
+  params->q_ptr = q.data_ptr();
+  params->k_ptr = k.data_ptr();
+  params->v_ptr = v.data_ptr();
+  params->q_row_stride = q.stride(-3);
+  params->k_row_stride = k.stride(-3);
+  params->v_row_stride = v.stride(-3);
+  params->q_head_stride = q.stride(-2);
+  params->k_head_stride = k.stride(-2);
+  params->v_head_stride = v.stride(-2);
+
+  if (out.numel() > 0) {
+    params->o_ptr = out.data_ptr();
+    params->o_row_stride = out.stride(-3);
+    params->o_head_stride = out.stride(-2);
+  }
+
+  params->has_rab = has_rab;
+  if (has_rab) {
+    params->rab_ptr = rab.data_ptr();
+    params->rab_seqlen_qk_stride = rab.stride(-4);
+    params->rab_seqlen_q_stride = rab.stride(-3);
+    params->rab_seqlen_k_stride = rab.stride(-2);
+    params->h_rab = h_rab;
+  } else {
+    params->rab_ptr = nullptr;
+    params->rab_seqlen_qk_stride = 0;
+    params->rab_seqlen_q_stride = 0;
+    params->rab_seqlen_k_stride = 0;
+    params->h_rab = 0;
+  }
+
+  params->num_contexts = static_cast<int*>(num_contexts_d);
+  params->cu_seqlens_q = static_cast<int*>(cu_seqlens_q_d);
+  params->cu_seqlens_k = static_cast<int*>(cu_seqlens_k_d);
+  params->num_targets = static_cast<int*>(num_targets_d);
+  params->seqused_q = static_cast<int*>(seqused_q_d);
+  params->seqused_k = static_cast<int*>(seqused_k_d);
+
+  params->quant_mode = quant_mode;
+  params->is_bf16 = true;  // FP8 forward uses the existing half-output metadata path.
+  params->is_e4m3 = true;
+  params->is_e5m2 = false;
+  params->output_dtype = 0;  // 0 = BF16
+
+  // FP8 descale factors (per-tensor, quant_mode=0).
+  if (descale_q.has_value()) {
+    params->descale_q_ptr = static_cast<float*>(descale_q.value().data_ptr());
+    params->descale_q_head_stride = descale_q.value().numel() > 1 ? 1 : 0;
+  }
+  if (descale_k.has_value()) {
+    params->descale_k_ptr = static_cast<float*>(descale_k.value().data_ptr());
+    params->descale_k_head_stride = descale_k.value().numel() > 1 ? 1 : 0;
+  }
+  if (descale_v.has_value()) {
+    params->descale_v_ptr = static_cast<float*>(descale_v.value().data_ptr());
+    params->descale_v_head_stride = descale_v.value().numel() > 1 ? 1 : 0;
+  }
+
+  params->b = b;
+  params->h = h;
+  params->h_k = h_k;
+  params->h_h_k_ratio = h / h_k;
+  params->seqlen_q = seqlen_q;
+  params->seqlen_k = seqlen_k;
+  params->seqlen_q_rounded = seqlen_q_rounded;
+  params->seqlen_k_rounded = seqlen_k_rounded;
+  params->scaling_seqlen = (scaling_seqlen == 0 || scaling_seqlen == (size_t)-1) ? seqlen_q : scaling_seqlen;
+  params->d = d;
+  params->alpha = alpha;
+  params->is_target = num_targets_d != nullptr;
+  params->target_group_size = target_group_size;
+  if (params->is_target) {
+    TORCH_CHECK(target_group_size > 0, "target_group_size must be positive");
+  }
+  params->is_context = num_contexts_d != nullptr;
+
+  if (window_size_left < 0 || window_size_left > (int)seqlen_k) window_size_left = seqlen_k;
+  if (window_size_right < 0 || window_size_right > (int)seqlen_k) window_size_right = seqlen_k;
+  params->window_size_left = window_size_left;
+  params->window_size_right = window_size_right;
+  params->is_causal = params->window_size_left == (int)seqlen_k && params->window_size_right == 0;
+  params->is_local = (window_size_left < (int)seqlen_k || window_size_right < (int)seqlen_k) &&
+      !params->is_causal;
+
+  params->is_arbitrary_mask = func.has_value() && func.value().defined();
+  if (params->is_arbitrary_mask) {
+    TORCH_CHECK(func.value().dtype() == torch::kInt32, "func must have dtype int32");
+    CHECK_DEVICE(func.value());
+    params->func_ptr = func.value().data_ptr();
+    params->func_ids_stride = func.value().stride(-2);
+    params->func_head_stride = func.value().stride(-3);
+    params->n_func = func.value().size(-2);
+    TORCH_CHECK(params->n_func == HSTU_ARBITRARY_NFUNC, "n_func mismatch");
+  }
+
+  params->is_paged_kv = is_paged_kv;
+  if (is_paged_kv) {
+    const at::Tensor& kv = kv_cache.value();
+    params->kv_cache_ptr = kv.data_ptr();
+    params->kv_cache_row_stride = kv.stride(-2);
+    params->kv_cache_head_stride = kv.stride(-3);
+    params->kv_cache_page_stride = kv.stride(-4);
+    params->kv_cache_kvtensor_stride = kv.stride(-5);
+    params->page_size = kv.size(-3);
+    params->total_pages = kv.size(-5);
+  } else {
+    params->kv_cache_ptr = nullptr;
+    params->page_size = 0;
+    params->total_pages = 0;
+  }
+  params->page_offsets = static_cast<int*>(page_offsets);
+  params->page_ids = static_cast<int*>(page_ids);
+  params->last_page_lens = static_cast<int*>(last_page_lens);
+
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename Dtype, bool Has_rab, bool Is_local, bool Is_causal,
+          bool Is_context, bool Is_target, bool Is_arbitrary, int kNFunc>
+void run_hstu_fwd_headdim_blackwell_rtx(Hstu_fwd_params& params, cudaStream_t stream) {
+  constexpr int Arch = 120;
+#ifndef HSTU_DISABLE_HDIM64
+  if (params.d == 64) {
+    run_hstu_fwd_<Arch, Dtype, 64, Has_rab, Is_local, Is_causal,
+        Is_context, Is_target, Is_arbitrary, kNFunc>(params, stream);
+    return;
+  }
+#endif
+#ifndef HSTU_DISABLE_HDIM32
+  if (params.d == 32) {
+    run_hstu_fwd_<Arch, Dtype, 32, Has_rab, Is_local, Is_causal,
+        Is_context, Is_target, Is_arbitrary, kNFunc>(params, stream);
+    return;
+  }
+#endif
+#ifndef HSTU_DISABLE_HDIM128
+  if (params.d == 128) {
+    run_hstu_fwd_<Arch, Dtype, 128, Has_rab, Is_local, Is_causal,
+        Is_context, Is_target, Is_arbitrary, kNFunc>(params, stream);
+    return;
+  }
+#endif
+#ifndef HSTU_DISABLE_HDIM256
+  if (params.d == 256) {
+    run_hstu_fwd_<Arch, Dtype, 256, Has_rab, Is_local, Is_causal,
+        Is_context, Is_target, Is_arbitrary, kNFunc>(params, stream);
+    return;
+  }
+#endif
+  TORCH_CHECK(
+      false,
+      "Unsupported head dim: ",
+      params.d,
+      " (Blackwell RTX FP8 supports 32/64/128/256)");
+}
+
+void run_hstu_fwd_blackwell_rtx(Hstu_fwd_params& params, cudaStream_t stream) {
+  TORCH_CHECK(params.quant_mode >= 0, "Blackwell RTX build only supports FP8 forward");
+  RAB_SWITCH(params.has_rab, Has_rab, [&] {
+    TORCH_CHECK(
+        params.d == 32 || params.d == 64 || params.d == 128 || params.d == 256,
+        "Blackwell RTX FP8 WS-only path supports headDim32/64/128/256, got headDim=",
+        params.d);
+    using FP8Type = cutlass::float_e4m3_t;
+#ifndef HSTU_DISABLE_ARBITRARY
+    if (params.is_arbitrary_mask) {
+      run_hstu_fwd_headdim_blackwell_rtx<FP8Type, Has_rab, false, false, false, false, true, HSTU_ARBITRARY_NFUNC>(params, stream);
+      return;
+    }
+#endif
+#ifndef HSTU_DISABLE_LOCAL
+    if (params.is_local) {
+      run_hstu_fwd_headdim_blackwell_rtx<FP8Type, Has_rab, true, false, false, false, false, 0>(params, stream);
+      return;
+    }
+#endif
+    if (!params.is_causal) {
+      run_hstu_fwd_headdim_blackwell_rtx<FP8Type, Has_rab, false, false, false, false, false, 0>(params, stream);
+      return;
+    }
+#ifndef HSTU_DISABLE_CAUSAL
+    CONTEXT_SWITCH(params.is_context, Is_context, [&] {
+      TARGET_SWITCH(params.is_target, Is_target, [&] {
+        run_hstu_fwd_headdim_blackwell_rtx<FP8Type, Has_rab, false, true, Is_context, Is_target, false, 0>(params, stream);
+      });
+    });
+#endif
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Main entry point: varlen forward for Blackwell RTX FP8.
+std::tuple<at::Tensor, at::Tensor> hstu_varlen_fwd_120(
+    const at::Tensor& q,   // total_q x num_heads x head_size
+    const at::Tensor& k,   // total_k x num_heads_k x head_size
+    const at::Tensor& v,   // total_k x num_heads_k x head_size
+    const at::Tensor& cu_seqlens_q,
+    const at::Tensor& cu_seqlens_k,
+    const std::optional<at::Tensor>& seqused_q,
+    const std::optional<at::Tensor>& seqused_k,
+    const int64_t max_seqlen_q,
+    const int64_t max_seqlen_k,
+    const int64_t scaling_seqlen,
+    const std::optional<at::Tensor>& num_contexts,
+    const std::optional<at::Tensor>& num_targets,
+    const int64_t target_group_size,
+    int64_t window_size_left,
+    int64_t window_size_right,
+    const double alpha,
+    std::optional<at::Tensor> rab,
+    const std::optional<at::Tensor>& func,
+    // FP8 arguments.
+    int64_t quant_mode,  // 0=per-tensor FP8, 2=blockwise FP8
+    const std::optional<at::Tensor>& descale_q,
+    const std::optional<at::Tensor>& descale_k,
+    const std::optional<at::Tensor>& descale_v,
+    const std::optional<at::Tensor>& sf_q_packed,
+    const std::optional<at::Tensor>& sf_k_packed,
+    const std::optional<at::Tensor>& sf_v_packed,
+    // Block-wise descale cumulative seqlens (quant_mode=2 only)
+    const std::optional<at::Tensor>& cu_seqlens_q_block_descale,
+    const std::optional<at::Tensor>& cu_seqlens_kv_block_descale,
+    const std::optional<at::Tensor>& cu_seqlens_v_block_descale,
+    const std::optional<at::Tensor>& kv_cache,
+    const std::optional<at::Tensor>& page_offsets,
+    const std::optional<at::Tensor>& page_ids,
+    const std::optional<at::Tensor>& last_page_lens) {
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  const int arch = dprops->major * 10 + dprops->minor;
+  TORCH_CHECK(arch >= 120, "hstu_varlen_fwd_120 requires Blackwell RTX GPU, got SM", arch);
+
+  auto q_dtype = q.dtype();
+  TORCH_CHECK(quant_mode >= 0, "Blackwell RTX build only supports FP8 forward");
+  TORCH_CHECK(q_dtype == at::kFloat8_e4m3fn,
+      "FP8 mode requires float8_e4m3fn input, got ", q_dtype);
+  TORCH_CHECK(k.dtype() == at::kFloat8_e4m3fn, "k must be float8_e4m3fn in FP8 mode");
+  TORCH_CHECK(v.dtype() == at::kFloat8_e4m3fn, "v must be float8_e4m3fn in FP8 mode");
+  TORCH_CHECK(quant_mode == 0 || quant_mode == 2,
+      "Blackwell RTX supports quant_mode=0 (per-tensor FP8) or quant_mode=2 (blockwise FP8), got ", quant_mode);
+  TORCH_CHECK(descale_q.has_value(), "descale_q required for FP8 mode");
+  TORCH_CHECK(descale_k.has_value(), "descale_k required for FP8 mode");
+  TORCH_CHECK(descale_v.has_value(), "descale_v required for FP8 mode");
+  if (quant_mode == 2) {
+    if (sf_q_packed.has_value()) {
+      TORCH_CHECK(sf_q_packed.value().dtype() == at::kInt, "sf_q_packed must be int32");
+    }
+    if (sf_k_packed.has_value()) {
+      TORCH_CHECK(sf_k_packed.value().dtype() == at::kInt, "sf_k_packed must be int32");
+    }
+    if (sf_v_packed.has_value()) {
+      TORCH_CHECK(sf_v_packed.value().dtype() == at::kInt, "sf_v_packed must be int32");
+    }
+  }
+
+  TORCH_CHECK(cu_seqlens_q.dtype() == at::kInt, "cu_seqlens_q must be int32");
+  TORCH_CHECK(cu_seqlens_k.dtype() == at::kInt, "cu_seqlens_k must be int32");
+
+  CHECK_DEVICE(q); CHECK_DEVICE(k); CHECK_DEVICE(v);
+  CHECK_DEVICE(cu_seqlens_q); CHECK_DEVICE(cu_seqlens_k);
+  CHECK_CONTIGUOUS(cu_seqlens_q); CHECK_CONTIGUOUS(cu_seqlens_k);
+
+  const int batch_size = cu_seqlens_q.numel() - 1;
+  const int num_heads = q.size(1);
+  const int head_size = q.size(2);
+  const int total_k = k.size(0);
+  const int num_heads_k = k.size(1);
+  const bool is_paged_kv = kv_cache.has_value() && page_offsets.has_value() &&
+      page_ids.has_value() && last_page_lens.has_value();
+  bool has_rab = rab.has_value();
+
+  CHECK_SHAPE(cu_seqlens_q, batch_size + 1);
+  CHECK_SHAPE(cu_seqlens_k, batch_size + 1);
+  CHECK_SHAPE(k, total_k, num_heads_k, head_size);
+  CHECK_SHAPE(v, total_k, num_heads_k, head_size);
+
+  TORCH_CHECK(batch_size > 0, "batch_size must be positive");
+  TORCH_CHECK(num_heads == num_heads_k, "num_heads_k must equal num_heads");
+  TORCH_CHECK(
+      head_size == 32 || head_size == 64 || head_size == 128 || head_size == 256,
+      "Blackwell RTX FP8 supports head_size 32, 64, 128, or 256, got ",
+      head_size);
+  TORCH_CHECK(q.stride(-1) == 1, "q must have contiguous last dimension");
+  TORCH_CHECK(k.stride(-1) == 1, "k must have contiguous last dimension");
+  // V must be row-major (d-stride=1). WS TMA path uses row-major V with LDSM_T transpose.
+  TORCH_CHECK(v.stride(-1) == 1,
+      "v must have contiguous last dimension (row-major)");
+
+  if (is_paged_kv) {
+    TORCH_CHECK(quant_mode == 2, "Blackwell RTX paged KV initial path requires quant_mode=2");
+    TORCH_CHECK(
+        head_size == 32 || head_size == 64 || head_size == 128 || head_size == 256,
+        "Blackwell RTX FP8 paged KV path requires head_size=32, 64, 128, or 256");
+    const bool is_no_target_paged_kv = !num_targets.has_value();
+    const bool is_causal_or_target_paged_kv =
+        num_targets.has_value() && window_size_left < 0 && window_size_right == 0;
+    TORCH_CHECK(
+        is_no_target_paged_kv || is_causal_or_target_paged_kv,
+        "Blackwell RTX FP8 paged KV supports no-target full/local/arbitrary windows, "
+        "or causal/target mode with num_targets and window_size_right=0");
+    const at::Tensor& kv = kv_cache.value();
+    CHECK_DEVICE(kv);
+    CHECK_CONTIGUOUS(kv);
+    TORCH_CHECK(kv.dtype() == at::kFloat8_e4m3fn,
+        "Blackwell RTX FP8 paged KV requires kv_cache dtype float8_e4m3fn");
+    TORCH_CHECK(kv.dim() == 5,
+        "kv_cache must have shape [total_pages, 2, page_size, num_heads_k, head_size]");
+    TORCH_CHECK(kv.size(1) == 2, "kv_cache second dimension must be 2 (K,V)");
+    TORCH_CHECK(kv.size(2) == 64,
+        "Blackwell RTX FP8 paged KV initial path requires page_size=64");
+    TORCH_CHECK(kv.size(3) == num_heads_k, "kv_cache num_heads_k mismatch");
+    TORCH_CHECK(kv.size(4) == head_size, "kv_cache head_size mismatch");
+    TORCH_CHECK(kv.stride(-1) == 1, "kv_cache must have contiguous last dimension");
+    CHECK_DEVICE(page_offsets.value());
+    CHECK_DEVICE(page_ids.value());
+    CHECK_DEVICE(last_page_lens.value());
+    CHECK_CONTIGUOUS(page_offsets.value());
+    CHECK_CONTIGUOUS(page_ids.value());
+    CHECK_CONTIGUOUS(last_page_lens.value());
+    TORCH_CHECK(page_offsets.value().dtype() == at::kInt, "page_offsets must be int32");
+    TORCH_CHECK(page_ids.value().dtype() == at::kInt, "page_ids must be int32");
+    TORCH_CHECK(last_page_lens.value().dtype() == at::kInt, "last_page_lens must be int32");
+    CHECK_SHAPE(page_offsets.value(), batch_size + 1);
+    CHECK_SHAPE(last_page_lens.value(), batch_size);
+    TORCH_CHECK(sf_k_packed.has_value() && sf_v_packed.has_value(),
+        "Blackwell RTX FP8 paged KV requires combined sf_k_packed and sf_v_packed");
+  } else {
+    TORCH_CHECK(!kv_cache.has_value() && !page_offsets.has_value() &&
+            !page_ids.has_value() && !last_page_lens.has_value(),
+        "kv_cache/page_offsets/page_ids/last_page_lens must either all be provided or all be None");
+  }
+
+  at::Tensor out = torch::empty({q.size(0), num_heads, head_size},
+      q.options().dtype(at::kHalf));
+
+  auto round_multiple = [](int x, int m) { return (x + m - 1) / m * m; };
+  // RAB is read by kBlockM x kBlockN TMA tiles in the RTX FP8 WS path, so pad
+  // both RAB dimensions to 128. Non-RAB only needs the legacy 16B alignment.
+  const int seqlen_q_rounded = round_multiple(max_seqlen_q, 16);
+  int rab_extent = max_seqlen_k;
+  if (has_rab) {
+    rab_extent = std::max(rab_extent, (int)rab.value().size(-2));
+    rab_extent = std::max(rab_extent, (int)rab.value().size(-1));
+  }
+  const int seqlen_k_rounded = round_multiple(rab_extent, has_rab ? 128 : 16);
+
+  int num_heads_rab = num_heads;
+  if (has_rab) {
+    num_heads_rab = rab.value().size(1);
+    CHECK_DEVICE(rab.value());
+    TORCH_CHECK(rab.value().stride(-1) == 1, "rab must have contiguous last dimension");
+    TORCH_CHECK(num_heads == num_heads_rab || num_heads_rab == 1, "rab num_heads mismatch");
+    TORCH_CHECK(rab.value().size(0) == batch_size, "rab batch size mismatch");
+    TORCH_CHECK(rab.value().size(2) >= max_seqlen_k,
+        "rab seqlen_q dimension must cover max_seqlen_k");
+    TORCH_CHECK(rab.value().size(3) >= max_seqlen_k,
+        "rab seqlen_k dimension must cover max_seqlen_k");
+    const int rab_q_pad = seqlen_k_rounded - rab.value().size(2);
+    const int rab_k_pad = seqlen_k_rounded - rab.value().size(3);
+    if (rab_q_pad != 0 || rab_k_pad != 0) {
+      rab = torch::nn::functional::pad(
+          rab.value(),
+          torch::nn::functional::PadFuncOptions({
+              0, rab_k_pad,
+              0, rab_q_pad}));
+    }
+  }
+
+  if (seqused_q.has_value()) {
+    CHECK_DEVICE(seqused_q.value());
+    CHECK_CONTIGUOUS(seqused_q.value());
+    CHECK_SHAPE(seqused_q.value(), batch_size);
+  }
+  if (seqused_k.has_value()) {
+    CHECK_DEVICE(seqused_k.value());
+    CHECK_CONTIGUOUS(seqused_k.value());
+    CHECK_SHAPE(seqused_k.value(), batch_size);
+  }
+
+  Hstu_fwd_params params;
+  set_params_fprop_blackwell_rtx(
+      &params,
+      batch_size, max_seqlen_q, max_seqlen_k,
+      scaling_seqlen, target_group_size,
+      seqlen_q_rounded, seqlen_k_rounded,
+      num_heads, num_heads_k, num_heads_rab,
+      head_size, static_cast<float>(alpha),
+      q, k, v,
+      has_rab ? rab.value() : at::Tensor(),
+      kv_cache,
+      out,
+      num_contexts.has_value() ? num_contexts.value().data_ptr() : nullptr,
+      cu_seqlens_q.data_ptr(),
+      cu_seqlens_k.data_ptr(),
+      seqused_q.has_value() ? seqused_q.value().data_ptr() : nullptr,
+      seqused_k.has_value() ? seqused_k.value().data_ptr() : nullptr,
+      page_offsets.has_value() ? page_offsets.value().data_ptr() : nullptr,
+      page_ids.has_value() ? page_ids.value().data_ptr() : nullptr,
+      last_page_lens.has_value() ? last_page_lens.value().data_ptr() : nullptr,
+      num_targets.has_value() ? num_targets.value().data_ptr() : nullptr,
+      has_rab,
+      is_paged_kv,
+      static_cast<int>(quant_mode),
+      func,
+      static_cast<int>(window_size_left),
+      static_cast<int>(window_size_right),
+      descale_q, descale_k, descale_v);
+
+  // Block-wise descale parameters (quant_mode=2 only)
+  if (quant_mode == 2) {
+    if (cu_seqlens_q_block_descale.has_value()) {
+      params.cu_seqlens_q_block_descale =
+          static_cast<int*>(cu_seqlens_q_block_descale.value().data_ptr());
+    }
+    if (cu_seqlens_kv_block_descale.has_value()) {
+      params.cu_seqlens_kv_block_descale =
+          static_cast<int*>(cu_seqlens_kv_block_descale.value().data_ptr());
+    }
+    // Head strides: descale_q/k/v are [head, total_blocks], stride(0) = total_blocks
+    if (descale_q.has_value() && descale_q.value().dim() >= 2) {
+      params.q_block_descale_head_stride = descale_q.value().stride(0);
+    }
+    if (descale_k.has_value() && descale_k.value().dim() >= 2) {
+      params.kv_block_descale_head_stride = descale_k.value().stride(0);
+    }
+    if (descale_v.has_value() && descale_v.value().dim() >= 2) {
+      params.v_block_descale_head_stride = descale_v.value().stride(0);
+    }
+    if (cu_seqlens_v_block_descale.has_value()) {
+      params.cu_seqlens_v_block_descale =
+          static_cast<int*>(cu_seqlens_v_block_descale.value().data_ptr());
+    }
+    if (sf_q_packed.has_value()) {
+      params.sf_q_packed_ptr = static_cast<int32_t*>(sf_q_packed.value().data_ptr());
+      // For TMA: use sf_q_packed.size(1) as head stride (PyTorch sets stride(0)=1 for H=1,
+      // which would make TMA globalDim[0]=1 < boxDim=kBlockM → fail).
+      if (sf_q_packed.value().dim() >= 2) {
+        params.q_block_descale_head_stride = sf_q_packed.value().size(1);
+      }
+    }
+    if (sf_k_packed.has_value()) {
+      params.sf_k_packed_ptr = static_cast<int32_t*>(sf_k_packed.value().data_ptr());
+      if (sf_k_packed.value().dim() >= 2) {
+        params.kv_block_descale_head_stride = sf_k_packed.value().size(1);
+      }
+    }
+    if (sf_v_packed.has_value()) {
+      params.sf_v_packed_ptr = static_cast<int32_t*>(sf_v_packed.value().data_ptr());
+      if (sf_v_packed.value().dim() >= 2) {
+        params.v_block_descale_head_stride = sf_v_packed.value().size(1);
+      }
+    }
+  }
+
+  params.total_k = total_k;  // Phase 5: needed for TMA descriptor covering full concat K/V
+  params.total_q = q.size(0);  // Phase 6 WS TMA: needed for TMA Q descriptor
+
+  if (total_k > 0) {
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    run_hstu_fwd_blackwell_rtx(params, stream);
+  } else {
+    out.zero_();
+  }
+
+  return {out, has_rab ? rab.value() : at::Tensor()};
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
+  m.def(
+      "hstu_varlen_fwd_120("
+      "Tensor q, Tensor k, Tensor v, "
+      "Tensor cu_seqlens_q, Tensor cu_seqlens_k, "
+      "Tensor? seqused_q, Tensor? seqused_k, "
+      "int max_seqlen_q, int max_seqlen_k, int scaling_seqlen, "
+      "Tensor? num_contexts, Tensor? num_targets, int target_group_size, "
+      "int window_size_left, int window_size_right, float alpha, "
+      "Tensor? rab, Tensor? func, "
+      "int quant_mode, "
+      "Tensor? descale_q, Tensor? descale_k, Tensor? descale_v, "
+      "Tensor? sf_q_packed, Tensor? sf_k_packed, Tensor? sf_v_packed, "
+      "Tensor? cu_seqlens_q_block_descale, Tensor? cu_seqlens_kv_block_descale, "
+      "Tensor? cu_seqlens_v_block_descale, "
+      "Tensor? kv_cache=None, Tensor? page_offsets=None, Tensor? page_ids=None, "
+      "Tensor? last_page_lens=None"
+      ") -> (Tensor, Tensor)");
+}
+
+TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
+  m.impl("hstu_varlen_fwd_120", hstu_varlen_fwd_120);
+}
+
+} // namespace fbgemm_gpu::hstu

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/kernel_traits.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/kernel_traits.h
@@ -1,0 +1,598 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Blackwell RTX kernel traits for HSTU forward pass.
+// Uses per-warp mma.sync (same model as Ampere), NOT warpgroup MMA (Hopper).
+// Provides BF16 and FP8 MMA atom selection.
+
+#pragma once
+
+#include <cutlass/numeric_types.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/layout/layout.h"
+
+#include "cute/atom/mma_traits_sm90_gmma.hpp"  // for GMMA::Layout_K_SW128_Atom / Layout_MN_SW128_Atom
+
+using namespace cute;
+
+// Base kernel traits for Blackwell RTX.
+// For BF16: uses SM80 mma.sync atom (available on Blackwell RTX via backward compat).
+// For FP8: uses Blackwell RTX f8f6f4 mma.sync atom when CUTE_ARCH_F8F6F4_MMA_ENABLED.
+template <
+    int kHeadDim_,
+    int kBlockM_,
+    int kBlockN_,
+    int kNWarps_,
+    typename elem_type = cutlass::bfloat16_t>
+struct Flash_kernel_traits_blackwell_rtx {
+  using Element = elem_type;
+  using ElementAccum = float;
+  using index_t = int64_t;
+
+  using MMA_Atom_Arch = std::conditional_t<
+      std::is_same_v<elem_type, cutlass::half_t>,
+      MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+      MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>>;
+
+  using SmemCopyAtom = Copy_Atom<SM75_U32x4_LDSM_N, elem_type>;
+  using SmemCopyAtomTransposed = Copy_Atom<SM75_U16x8_LDSM_T, elem_type>;
+};
+
+// Blackwell RTX BF16 forward kernel traits — identical structure to Ampere.
+// Compiled with -gencode arch=compute_120,code=sm_120 for native Blackwell execution.
+template <
+    int kHeadDim_,
+    int kBlockM_,
+    int kBlockN_,
+    int kNWarps_,
+    bool Is_causal_,
+    bool Is_target_,
+    bool Is_context_,
+    bool Is_local_,
+    bool Is_arbitrary_,
+    int kNFunc_,
+    bool Has_rab_,
+    bool Is_Q_in_regs_ = false,
+    bool Share_Q_K_smem_ = false,
+    typename elem_type = cutlass::bfloat16_t,
+    typename Base =
+        Flash_kernel_traits_blackwell_rtx<kHeadDim_, kBlockM_, kBlockN_, kNWarps_, elem_type>>
+struct Hstu_fwd_kernel_traits_blackwell_rtx : public Base {
+  static constexpr bool Is_causal = Is_causal_;
+  static constexpr bool Is_target = Is_target_;
+  static constexpr bool Is_context = Is_context_;
+  static constexpr bool Is_local = Is_local_;
+  static constexpr bool Is_arbitrary = Is_arbitrary_;
+  static constexpr int kNFunc = Is_arbitrary_ ? kNFunc_ : 0;
+  static constexpr bool Has_rab = Has_rab_;
+  static constexpr bool Paged_KV = false;  // Not supported in first Blackwell impl
+  static constexpr bool Is_fp8 = false;
+
+  using Element = typename Base::Element;
+  // For BF16 path: ElementSmem == Element (no conversion needed)
+  using ElementSmem = Element;
+  // For BF16 path: OutputType == Element (output same dtype as input)
+  using OutputType = Element;
+  using ElementAccum = typename Base::ElementAccum;
+  using index_t = typename Base::index_t;
+  using SmemCopyAtom = typename Base::SmemCopyAtom;
+  using SmemCopyAtomTransposed = typename Base::SmemCopyAtomTransposed;
+
+  static constexpr bool Share_Q_K_smem = Share_Q_K_smem_;
+  static constexpr bool Is_Q_in_regs = Is_Q_in_regs_ || Share_Q_K_smem;
+
+  static constexpr int kNWarps = kNWarps_;
+  static constexpr int kNThreads = kNWarps * cutlass::NumThreadsPerWarp;
+
+  static constexpr int kBlockM = kBlockM_;
+  static constexpr int kBlockN = kBlockN_;
+  static constexpr int kHeadDim = kHeadDim_;
+  static_assert(kHeadDim % 32 == 0);
+  static constexpr int kBlockKSmem = kHeadDim % 64 == 0 ? 64 : 32;
+  static constexpr int kBlockKSmemRab = kBlockN % 64 == 0 ? 64 : 32;
+  static constexpr int kBlockKGmem =
+      kHeadDim % 128 == 0 ? 128 : (kHeadDim % 64 == 0 ? 64 : 32);
+  static constexpr int kSwizzle = kBlockKSmem == 32 ? 2 : 3;
+  static constexpr int kSwizzleRab = kBlockKSmemRab == 32 ? 2 : 3;
+  static constexpr int kStages = 1;
+
+  using TiledMma = TiledMMA<
+      typename Base::MMA_Atom_Arch,
+      Layout<Shape<Int<kNWarps>, _1, _1>>,
+      Tile<Int<16 * kNWarps>, _16, _16>>;
+  static_assert(16 * kNWarps <= kBlockM);
+
+  using SmemLayoutAtomQ = decltype(composition(
+      Swizzle<kSwizzle, 3, 3>{},
+      Layout<Shape<_8, Int<kBlockKSmem>>, Stride<Int<kBlockKSmem>, _1>>{}));
+
+  using SmemLayoutAtomRab = decltype(composition(
+      Swizzle<kSwizzleRab, 3, 3>{},
+      Layout<Shape<_8, Int<kBlockKSmemRab>>, Stride<Int<kBlockKSmemRab>, _1>>{}));
+
+  using SmemLayoutQ = decltype(tile_to_shape(
+      SmemLayoutAtomQ{},
+      Shape<Int<kBlockM>, Int<kHeadDim>>{}));
+  using SmemLayoutRab = decltype(tile_to_shape(
+      SmemLayoutAtomRab{},
+      Shape<Int<kBlockM>, Int<kBlockN>, Int<kStages>>{}));
+  using SmemLayoutKV = decltype(tile_to_shape(
+      SmemLayoutAtomQ{},
+      Shape<Int<kBlockN>, Int<kHeadDim>, Int<kStages>>{}));
+
+  using SmemLayoutVtransposed = decltype(composition(
+      SmemLayoutKV{},
+      make_layout(Shape<Int<kHeadDim>, Int<kBlockN>, Int<kStages>>{},
+          Stride<Int<kBlockN>, _1, Int<kHeadDim * kBlockN>>{})));
+  using SmemLayoutVtransposedNoSwizzle =
+      decltype(get_nonswizzle_portion(SmemLayoutVtransposed{}));
+
+  using SmemLayoutAtomO = decltype(composition(
+      Swizzle<kSwizzle, 3, 3>{},
+      Layout<Shape<Int<8>, Int<kBlockKSmem>>, Stride<Int<kBlockKSmem>, _1>>{}));
+  using SmemLayoutO = decltype(tile_to_shape(
+      SmemLayoutAtomO{},
+      Shape<Int<kBlockM>, Int<kHeadDim>>{}));
+  using SmemCopyAtomO = Copy_Atom<AutoVectorizingCopy, Element>;
+
+  static constexpr int MaxSeqLenK = 64 * 1024;
+  static constexpr int MaxValidBlock = MaxSeqLenK / kBlockN;
+  using SmemLayoutValidBlockIds = Layout<Shape<Int<MaxValidBlock>>, Stride<_1>>;
+  using SmemLayoutMaxFunc = Layout<Shape<Int<kNFunc/2 + 1>>, Stride<_1>>;
+  using SmemLayoutMinFunc = Layout<Shape<Int<kNFunc/2 + 1>>, Stride<_1>>;
+
+  static constexpr int kSmemQSize = size(SmemLayoutQ{}) * sizeof(Element);
+  static constexpr int kSmemRabSize =
+      Has_rab ? size(SmemLayoutRab{}) * sizeof(Element) : 0;
+  static constexpr int kSmemKVSize = size(SmemLayoutKV{}) * 2 * sizeof(Element);
+  static constexpr int kSmemSizeQKV = Share_Q_K_smem
+      ? std::max(kSmemQSize, kSmemKVSize)
+      : kSmemQSize + kSmemKVSize;
+  static constexpr int kSmemSizeQKVRab = kSmemSizeQKV + kSmemRabSize;
+  static constexpr int kSmemSizeQKVRabValidBlockIds = kSmemSizeQKVRab +
+      (Is_arbitrary ? size(SmemLayoutValidBlockIds{}) * sizeof(int) : 0);
+  static constexpr int kSmemSize = kSmemSizeQKVRabValidBlockIds +
+      (Is_arbitrary ? (size(SmemLayoutMaxFunc{}) + size(SmemLayoutMinFunc{}) + 1) * sizeof(int) : 0);
+
+  static constexpr int kGmemElemsPerLoad =
+      sizeof(cute::uint128_t) / sizeof(Element);
+  static_assert(kHeadDim % kGmemElemsPerLoad == 0);
+  static constexpr int kGmemThreadsPerRow = kBlockKSmem / kGmemElemsPerLoad;
+  static constexpr int kGmemThreadsPerRowRab = kBlockKSmemRab / kGmemElemsPerLoad;
+  static_assert(kNThreads % kGmemThreadsPerRow == 0);
+  static_assert(kNThreads % kGmemThreadsPerRowRab == 0);
+
+  using GmemLayoutAtom = Layout<
+      Shape<Int<kNThreads / kGmemThreadsPerRow>, Int<kGmemThreadsPerRow>>,
+      Stride<Int<kGmemThreadsPerRow>, _1>>;
+  using GmemLayoutAtomRab = Layout<
+      Shape<Int<kNThreads / kGmemThreadsPerRowRab>, Int<kGmemThreadsPerRowRab>>,
+      Stride<Int<kGmemThreadsPerRowRab>, _1>>;
+
+  using Gmem_copy_struct = SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>;
+  using GmemTiledCopyQKV = decltype(make_tiled_copy(
+      Copy_Atom<Gmem_copy_struct, Element>{},
+      GmemLayoutAtom{},
+      Layout<Shape<_1, _8>>{}));
+
+  // rab_row_size: M-values per thread per atom call; must cover exactly kBlockM rows total.
+  static constexpr int rab_row_size = Has_rab
+      ? kBlockM * kGmemThreadsPerRowRab / kNThreads
+      : 1;
+  using GmemTiledCopyRab = decltype(make_tiled_copy(
+      Copy_Atom<Gmem_copy_struct, Element>{},
+      GmemLayoutAtomRab{},
+      Layout<Shape<Int<rab_row_size>, _8>, Stride<_8, _1>>{}));
+
+  using GmemTiledCopyO = decltype(make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, Element>{},
+      GmemLayoutAtom{},
+      Layout<Shape<_1, _8>>{}));
+};
+
+// Common Blackwell RTX FP8 forward kernel traits.
+// Q, K, V are FP8 (e4m3) in both GMEM and SMEM. The WS TMA kernel consumes
+// these layouts and applies block-scale factors in Blackwell RTX QMMA.
+template <
+    int kHeadDim_,
+    int kBlockM_,
+    int kBlockN_,
+    int kNWarps_,
+    bool Is_causal_,
+    bool Is_target_,
+    bool Is_context_,
+    bool Is_local_,
+    bool Is_arbitrary_,
+    int kNFunc_,
+    bool Has_rab_,
+    bool Paged_KV_ = false,
+    bool Is_Q_in_regs_ = false,
+    bool Share_Q_K_smem_ = false,
+    typename out_type = cutlass::bfloat16_t>
+struct Hstu_fwd_kernel_traits_blackwell_rtx_fp8 {
+  // Common Blackwell RTX FP8 metadata used by the WS TMA kernel.
+  // All Blackwell RTX FP8 forward dispatch routes through Hstu_fwd_kernel_traits_blackwell_rtx_fp8_ws.
+  // The legacy non-WS FP8 launch path has been removed.
+  using Element = cutlass::float_e4m3_t;
+  using ElementSmem = cutlass::float_e4m3_t;
+  using ElementAccum = float;
+  using OutputType = out_type;
+  using index_t = int64_t;
+
+  static constexpr bool Is_causal = Is_causal_;
+  static constexpr bool Is_target = Is_target_;
+  static constexpr bool Is_context = Is_context_;
+  static constexpr bool Is_local = Is_local_;
+  static constexpr bool Is_arbitrary = Is_arbitrary_;
+  static constexpr int kNFunc = Is_arbitrary_ ? kNFunc_ : 0;
+  static constexpr bool Has_rab = Has_rab_;
+  static constexpr bool Paged_KV = Paged_KV_;
+  static constexpr bool Is_fp8 = true;
+
+  // Note: MMA_Atom_Arch / TiledMma / SmemCopyAtom are intentionally absent here.
+  // The WS kernel uses BlackwellRtxQmmaBuilder (BS1/BS2) for MMA and s2r copies directly.
+
+  static constexpr bool Share_Q_K_smem = Share_Q_K_smem_;
+  static constexpr bool Is_Q_in_regs = Is_Q_in_regs_ || Share_Q_K_smem;
+
+  static constexpr int kNWarps = kNWarps_;
+  static constexpr int kNThreads = kNWarps * cutlass::NumThreadsPerWarp;
+
+  static constexpr int kBlockM = kBlockM_;
+  static constexpr int kBlockN = kBlockN_;
+  static constexpr int kHeadDim = kHeadDim_;
+  static_assert(kHeadDim % 32 == 0);
+  // kBlockKSmem=32: one 16×32 FP8 atom aligns with Blackwell RTX QMMA K=32 per step.
+  static constexpr int kBlockKSmem = 32;
+  static constexpr int kBlockKSmemRab = kBlockN % 64 == 0 ? 64 : 32;
+  static constexpr int kBlockKGmem =
+      kHeadDim % 128 == 0 ? 128 : (kHeadDim % 64 == 0 ? 64 : 32);
+  static constexpr int kSwizzle = kBlockKSmem == 32 ? 2 : 3;
+  // RAB is always BF16: use 64-BF16 strip with Swizzle<3,3,3> (8 BF16 contiguous = 128 bits)
+  static constexpr int kSwizzleRab = kBlockKSmemRab == 32 ? 2 : 3;
+  static constexpr int kStages = 1;
+
+  // SMEM layout for Q/K/V: flat 16×32 atom (kBlockKSmem=32).
+  // 16-row × 32-col FP8 tile = 512 bytes; aligns with Blackwell RTX QMMA K=32 per step.
+  using SmemLayoutAtomQ =
+      Layout<Shape<_16, _32>, Stride<_32, _1>>;
+
+  using SmemLayoutAtomRab = decltype(composition(
+      Swizzle<kSwizzleRab, 3, 3>{},
+      Layout<Shape<_8, Int<kBlockKSmemRab>>, Stride<Int<kBlockKSmemRab>, _1>>{}));
+
+  using SmemLayoutQ = decltype(tile_to_shape(
+      SmemLayoutAtomQ{},
+      Shape<Int<kBlockM>, Int<kHeadDim>>{}));
+  using SmemLayoutRab = decltype(tile_to_shape(
+      SmemLayoutAtomRab{},
+      Shape<Int<kBlockM>, Int<kBlockN>, Int<kStages>>{}));
+  using SmemLayoutKV = decltype(tile_to_shape(
+      SmemLayoutAtomQ{},
+      Shape<Int<kBlockN>, Int<kHeadDim>, Int<kStages>>{}));
+
+  using SmemLayoutVtransposed = decltype(composition(
+      SmemLayoutKV{},
+      make_layout(Shape<Int<kHeadDim>, Int<kBlockN>, Int<kStages>>{},
+          Stride<Int<kBlockN>, _1, Int<kHeadDim * kBlockN>>{})));
+  using SmemLayoutVtransposedNoSwizzle =
+      decltype(get_nonswizzle_portion(SmemLayoutVtransposed{}));
+
+  // WS TMA layouts: choose the smallest GMMA K-swizzle atom that matches the
+  // contiguous head-dim tile.
+  using SmemLayoutAtomTMA = std::conditional_t<
+      (kHeadDim == 32),
+      GMMA::Layout_K_SW32_Atom<Element>,
+      std::conditional_t<
+          (kHeadDim == 64),
+          GMMA::Layout_K_SW64_Atom<Element>,
+          GMMA::Layout_K_SW128_Atom<Element>>>;
+  using SmemLayoutQ_TMA  = decltype(tile_to_shape(SmemLayoutAtomTMA{}, Shape<Int<kBlockM>, Int<kHeadDim>>{}));
+  using SmemLayoutK_TMA  = decltype(tile_to_shape(SmemLayoutAtomTMA{}, Shape<Int<kBlockN>, Int<kHeadDim>>{}));
+  // V row-major [kBlockN, kHeadDim] in SMEM, loaded via TMA from row-major V (d stride-1).
+  // K_SW128_Atom: dim1 = kHeadDim (d axis) is the SMEM fast axis; dim0 = kBlockN (n_k, token).
+  // Physical byte: physical(n_k, d) = n_k * kHeadDim + (d ^ ((n_k & 7) << 4)).
+  // LDSM_T address for n_k row, d-group: addr = v_base + n_k * kHeadDim + (d_start ^ ((n_k & 7) << 4)). ✓
+  using SmemLayoutVt_TMA = decltype(tile_to_shape(
+      SmemLayoutAtomTMA{},
+      Shape<Int<kBlockN>, Int<kHeadDim>>{}));
+
+  // Output layout: BF16 written to sO (reuses smem_ base), then copied to GMEM.
+  // Blackwell RTX QMMA output uses PermMmaTileN = Layout<_8,_4,_4>, Stride<_1,_32,_8>, which
+  // permutes the N-axis of the C fragment. The interleaved atom below matches this permutation:
+  // within each 8-element group (cols 0..7, 8..15, etc.), elements are consecutive in physical
+  // SMEM (stride-1 within group, stride-64 between groups). This enables AutoVectorizingCopy
+  // to perform 8-element (128-bit) stores correctly.
+  // Reference: Blackwell block-scaled MoE GEMM SmemAtomLayoutO.
+  // NOTE: kBlockKSmem=32 is for FP8 INPUT; output is BF16 with 64-wide SW128 atom.
+  using SmemLayoutAtomO = std::conditional_t<
+      (kHeadDim == 32),
+      Layout<Shape<_8, _32>, Stride<_32, _1>>,
+      decltype(composition(
+          Swizzle<3, 3, 3>{},
+          Layout<Shape<_8, Shape<_8, _8>>, Stride<_8, Stride<_1, Int<64>>>>{}))>;
+  using SmemLayoutO = decltype(tile_to_shape(
+      SmemLayoutAtomO{},
+      Shape<Int<kBlockM>, Int<kHeadDim>>{}));
+  using SmemCopyAtomO = Copy_Atom<AutoVectorizingCopy, OutputType>;
+
+  static constexpr int MaxSeqLenK = 64 * 1024;
+  static constexpr int MaxValidBlock = MaxSeqLenK / kBlockN;
+  using SmemLayoutValidBlockIds = Layout<Shape<Int<MaxValidBlock>>, Stride<_1>>;
+  using SmemLayoutMaxFunc = Layout<Shape<Int<kNFunc/2 + 1>>, Stride<_1>>;
+  using SmemLayoutMinFunc = Layout<Shape<Int<kNFunc/2 + 1>>, Stride<_1>>;
+
+  // SMEM sizes: FP8 is 1 byte each (half of BF16), allowing kNWarps=8
+  static constexpr int kSmemQSize = size(SmemLayoutQ{}) * sizeof(Element);
+  static constexpr int kSmemRabSize =
+      Has_rab ? size(SmemLayoutRab{}) * sizeof(cutlass::bfloat16_t) : 0;  // RAB is always BF16
+  static constexpr int kSmemKVSize = size(SmemLayoutKV{}) * 2 * sizeof(Element);
+  // FP8 epilogue writes BF16 output into sO which reuses smem_ base.
+  // sO needs size(SmemLayoutO) * sizeof(OutputType) bytes (BF16 = 2x FP8).
+  // kSmemSizeQKV must be >= kSmemOSize to avoid OOB SMEM access in epilogue.
+  static constexpr int kSmemOSize = size(SmemLayoutO{}) * sizeof(OutputType);
+  // Phase 3 single-buffer V layout (when Share_Q_K_smem=true):
+  //   [0, kSmemQSize)       Q = K  (shared, single buffer)
+  //   [kSmemQSize, 2x)      V (single buffer)
+  // kSmemOSize (BF16 epilogue) = kBlockM*kHeadDim*2 = 128*128*2 = 32768 = 2*kSmemQSize,
+  // so output can reuse smem_q safely.
+  static constexpr int kSmemSizeQKV = Share_Q_K_smem
+      ? std::max(2 * kSmemQSize, kSmemOSize)   // Q=K(0) + V(1), single-buf V
+      : std::max(kSmemQSize + kSmemKVSize, kSmemOSize);
+  static constexpr int kSmemSizeQKVRab = kSmemSizeQKV + kSmemRabSize;
+  static constexpr int kSmemSizeQKVRabValidBlockIds = kSmemSizeQKVRab +
+      (Is_arbitrary ? size(SmemLayoutValidBlockIds{}) * sizeof(int) : 0);
+  // Extra SMEM for block-scale SF: SFA (kBlockM int32 = 512B) + SFB (kBlockN int32 = 512B)
+  static constexpr int kSmemSFSize = 1024;
+  // Extra SMEM for TMA barrier(s). The base FP8 layout keeps one barrier slot;
+  // WS traits define their own producer/consumer mbarrier area below.
+  static constexpr int kSmemMbarSize = 8;
+  static constexpr int kSmemSize = kSmemSizeQKVRabValidBlockIds +
+      (Is_arbitrary ? (size(SmemLayoutMaxFunc{}) + size(SmemLayoutMinFunc{}) + 1) * sizeof(int) : 0) +
+      kSmemSFSize + kSmemMbarSize;
+
+  // GMEM copy: cp.async FP8 elements directly into flat SMEM (no conversion).
+  // Uses SM80_CP_ASYNC_CACHEGLOBAL<uint128_t> (16 bytes = 16 FP8 per thread per load).
+  // Flat SMEM layout has stride-1 in K → 16 consecutive FP8 are physically contiguous. ✓
+  static constexpr int kGmemElemsPerLoad = sizeof(cute::uint128_t) / sizeof(Element);  // = 16 for FP8
+  static constexpr int kGmemThreadsPerRow = kBlockKSmem / kGmemElemsPerLoad;  // = 32/16 = 2 for FP8
+  // RAB is always BF16: 8 BF16 per uint128_t (16 bytes)
+  static constexpr int kGmemElemsPerLoadRab = sizeof(cute::uint128_t) / sizeof(cutlass::bfloat16_t);
+  static constexpr int kGmemThreadsPerRowRab = kBlockKSmemRab / kGmemElemsPerLoadRab;
+  static_assert(kHeadDim % kGmemElemsPerLoad == 0);
+  static_assert(kNThreads % kGmemThreadsPerRow == 0);
+  static_assert(kNThreads % kGmemThreadsPerRowRab == 0);
+
+  using GmemLayoutAtom = Layout<
+      Shape<Int<kNThreads / kGmemThreadsPerRow>, Int<kGmemThreadsPerRow>>,
+      Stride<Int<kGmemThreadsPerRow>, _1>>;
+  using GmemLayoutAtomRab = Layout<
+      Shape<Int<kNThreads / kGmemThreadsPerRowRab>, Int<kGmemThreadsPerRowRab>>,
+      Stride<Int<kGmemThreadsPerRowRab>, _1>>;
+
+  // cp.async for FP8 Q/K/V: loads 16 FP8 (128-bit) directly into flat FP8 SMEM per thread.
+  // CACHEGLOBAL<uint128_t> issues `cp.async.cg` (L1-bypass), accepts 16-byte transfers.
+  using Gmem_copy_struct = SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>;
+  using GmemTiledCopyQKV = decltype(make_tiled_copy(
+      Copy_Atom<Gmem_copy_struct, Element>{},
+      GmemLayoutAtom{},
+      Layout<Shape<_1, Int<kGmemElemsPerLoad>>>{}));  // 16 FP8 per thread
+
+  // RAB is BF16 (not quantized)
+  using Gmem_copy_struct_rab = SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>;
+  // rab_row_size: M-values per thread per atom call in the RAB copy.
+  // Must satisfy: (kNThreads / kGmemThreadsPerRowRab) * rab_row_size == kBlockM
+  // so the tiled copy covers exactly [kBlockM, kBlockN] BF16 elements without
+  // threads writing beyond kBlockM rows (which would corrupt SMEM past sRab).
+  // Formula: kBlockM * kGmemThreadsPerRowRab / kNThreads
+  // For kBlockM=128, kNThreads=256, kGmemThreadsPerRowRab=8: 128*8/256 = 4. ✓
+  static constexpr int rab_row_size = Has_rab
+      ? kBlockM * kGmemThreadsPerRowRab / kNThreads
+      : 1;
+  using GmemTiledCopyRab = decltype(make_tiled_copy(
+      Copy_Atom<Gmem_copy_struct_rab, cutlass::bfloat16_t>{},
+      GmemLayoutAtomRab{},
+      Layout<Shape<Int<rab_row_size>, _8>, Stride<_8, _1>>{}));
+
+  // Output copy (BF16 or FP16): uses OutputType-sized loads (not FP8-sized).
+  // SmemLayoutAtomO has 64-wide BF16 row (128-byte SW128 atom).
+  // kGmemThreadsPerRowO must be 64/8=8 for BF16 output — NOT kBlockKSmem=32 (FP8 input).
+  static constexpr int kGmemElemsPerLoadO =
+      sizeof(cute::uint128_t) / sizeof(OutputType);  // = 8 for BF16
+  static constexpr int kGmemThreadsPerRowO = 64 / kGmemElemsPerLoadO;  // = 8
+  using GmemLayoutAtomO = Layout<
+      Shape<Int<kNThreads / kGmemThreadsPerRowO>, Int<kGmemThreadsPerRowO>>,
+      Stride<Int<kGmemThreadsPerRowO>, _1>>;
+  using GmemTiledCopyO = decltype(make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopy, OutputType>{},
+      GmemLayoutAtomO{},
+      Layout<Shape<_1, Int<kGmemElemsPerLoadO>>>{}));
+};
+
+template <int kHeadDim_, int kBlockM_, typename OutType_>
+struct Hstu_blackwell_rtx_ws_o_tma_layout {
+  using type = Layout<
+      Shape<Int<kBlockM_>, Int<kHeadDim_>>,
+      Stride<Int<kHeadDim_>, _1>>;
+};
+
+template <int kBlockM_, typename OutType_>
+struct Hstu_blackwell_rtx_ws_o_tma_layout<32, kBlockM_, OutType_> {
+  using type = decltype(tile_to_shape(
+      GMMA::Layout_K_SW32_Atom<OutType_>{},
+      Shape<Int<kBlockM_>, Int<32>>{}));
+};
+
+template <int kBlockM_, typename OutType_>
+struct Hstu_blackwell_rtx_ws_o_tma_layout<64, kBlockM_, OutType_> {
+  using type = decltype(tile_to_shape(
+      GMMA::Layout_K_SW64_Atom<OutType_>{},
+      Shape<Int<kBlockM_>, Int<64>>{}));
+};
+
+template <int kBlockM_, typename OutType_>
+struct Hstu_blackwell_rtx_ws_o_tma_layout<128, kBlockM_, OutType_> {
+  using type = decltype(tile_to_shape(
+      GMMA::Layout_K_SW128_Atom<OutType_>{},
+      Shape<Int<kBlockM_>, Int<128>>{}));
+};
+
+template <int kBlockM_, typename OutType_>
+struct Hstu_blackwell_rtx_ws_o_tma_layout<256, kBlockM_, OutType_> {
+  using type = decltype(tile_to_shape(
+      GMMA::Layout_K_SW128_Atom<OutType_>{},
+      Shape<Int<kBlockM_>, Int<256>>{}));
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Warp-specialized FP8 kernel traits.
+// Extends the common FP8 metadata with dedicated load/store warps and 8 math warps.
+// kNThreads = 288 (9 warps × 32), kNMathThreads = 256 (8 math warps × 32).
+// Math warps use tidx_math = tidx - 32 ∈ [0, 255].
+// All GMEM/SMEM layout arithmetic (SmemLayoutQ, GmemTiledCopyQKV, etc.) is inherited from
+// the base FP8 traits where kNThreads=256, so those layouts remain correct for 256 math threads.
+template <
+    int kHeadDim_,
+    int kBlockM_,
+    int kBlockN_,
+    int kNWarps_,   // number of MATH warps (= 8 for kBlockM=128)
+    bool Is_causal_,
+    bool Is_target_,
+    bool Is_context_,
+    bool Is_local_,
+    bool Is_arbitrary_,
+    int kNFunc_,
+    bool Has_rab_,
+    bool Paged_KV_ = false,
+    bool Is_Q_in_regs_ = false,
+    bool Share_Q_K_smem_ = false,
+    typename out_type = cutlass::bfloat16_t>
+struct Hstu_fwd_kernel_traits_blackwell_rtx_fp8_ws
+    : public Hstu_fwd_kernel_traits_blackwell_rtx_fp8<
+          kHeadDim_, kBlockM_, kBlockN_, kNWarps_,
+          Is_causal_, Is_target_, Is_context_, Is_local_, Is_arbitrary_, kNFunc_, Has_rab_,
+          Paged_KV_, Is_Q_in_regs_, Share_Q_K_smem_, out_type> {
+  using Base = Hstu_fwd_kernel_traits_blackwell_rtx_fp8<
+      kHeadDim_, kBlockM_, kBlockN_, kNWarps_,
+      Is_causal_, Is_target_, Is_context_, Is_local_, Is_arbitrary_, kNFunc_, Has_rab_,
+      Paged_KV_, Is_Q_in_regs_, Share_Q_K_smem_, out_type>;
+
+  // Warp roles:
+  //   warps 0..kNWarps_-1  = math warps  (WG0: warps 0-3, WG1: warps 4-7)
+  //   warps kNWarps_..+3   = load warpgroup WG2 (warps 8-11, 4 warps = 1 complete warpgroup)
+  //     warp kNWarps_      = Q/SFA TMA load
+  //     warp kNWarps_+1    = K/SFB TMA load
+  //     warp kNWarps_+2    = V/SFV TMA load
+  //     warp kNWarps_+3    = O TMA store
+  // Having a complete WG2 allows setmaxnreg WARPSYNC.ALL retry loop to function correctly.
+  static constexpr int kNMathWarps   = kNWarps_;     // 8 math warps
+  static constexpr int kNLoadWarps   = 4;            // Q, K, V, and O-specialized load/store warps
+  static constexpr int kLoadWarpIdx  = kNWarps_;     // warp 8 starts the load warpgroup
+
+  // kNThreads overrides Base::kNThreads: total = 8 math + 4 load = 12 warps × 32 = 384.
+  static constexpr int kNThreads     = (kNMathWarps + kNLoadWarps) * cutlass::NumThreadsPerWarp;  // 384
+  // kNMathThreads: math-warp-only thread count used for per-warp layout arithmetic.
+  static constexpr int kNMathThreads = kNMathWarps * cutlass::NumThreadsPerWarp;  // 256
+
+  // Double-buffer KV SMEM layout.
+  // Each K or Vt tile is kBlockN * kHeadDim FP8 bytes (1 byte each).
+  static constexpr int kSmemKVBytes =
+      Base::kBlockN * Base::kHeadDim * (int)sizeof(typename Base::Element);
+  // hdim256 arbitrary needs ValidBlockIds SMEM; two KV stages would exceed Blackwell RTX's
+  // 101376B opt-in limit.  RAB-in-SMEM also needs a 128x64 BF16 tile; for D256
+  // RAB and D128 arbitrary+RAB we release one KV stage to stay under the limit.
+  static constexpr bool kUseRabSmem = Has_rab_;
+  static constexpr bool kUseSingleKVStage =
+      (Is_arbitrary_ && kHeadDim_ > 128) ||
+      (kUseRabSmem && (kHeadDim_ > 128 || (Is_arbitrary_ && kHeadDim_ == 128)));
+  static constexpr int kSmemWsKVStages = kUseSingleKVStage ? 1 : 2;
+  static constexpr int kSmemWsRabStages = kUseRabSmem ? 1 : 0;
+  static constexpr int kSmemWsRabLayoutStages = 1;
+
+  // Producer/consumer mbarriers: ready barriers model cnt=1, empty barriers model cnt=0.
+  //   k_ready[0/1]: K/SFK TMA completion per stage
+  //   v_ready[0/1]: V/SFV TMA completion per stage
+  //   k_empty[0/1]: K/SFK consumed into registers per stage
+  //   v_empty[0/1]: V/SFV consumed into registers per stage
+  //   q_ready: Q/SFA TMA completion
+  //   q_empty: Q/SFA consumed into registers
+  //   o_ready[0]: O SMEM ready for TMA store
+  //   o_empty[0]: independent O SMEM buffer is free for math epilogue writes
+  // Each barrier is 8 bytes.  RAB-in-SMEM adds one ready/empty pair.
+  static constexpr int kSmemMbarSize = kUseRabSmem ? 128 : 112;
+  // kSmemWsKVStages × (K + Vt).
+  static constexpr int kSmemWsKVTotalBytes = 2 * kSmemWsKVStages * kSmemKVBytes;
+
+  // WS SMEM region offsets (double-buffer layout):
+  //   [0 .. kSmemWsKVTotalBytes)          : K/Vt stages (one stage for hdim256 arbitrary, otherwise two)
+  //   [kSmemWsKVTotalBytes .. +ValidBl)   : ValidBlockIds (Is_arbitrary only)
+  //   [.. + func region)                  : func arrays (Is_arbitrary only)
+  //   [padded to 8B)                      : SFA(512B) + SFB(512B) = 1024B
+  //   [last kSmemMbarSize bytes)          : 14 or 16 mbarriers × 8B
+  static constexpr int kSmemWsValidBlockIdsOffset = kSmemWsKVTotalBytes;
+  static constexpr int kSmemWsFuncOffset = kSmemWsValidBlockIdsOffset +
+      (Is_arbitrary_ ? (int)(size(typename Base::SmemLayoutValidBlockIds{}) * sizeof(int)) : 0);
+  // Arbitrary func data: sn_valid_block_max (1 int) + sFunc_min (kNFunc/2+1 ints) + sFunc_max (kNFunc/2+1 ints)
+  static constexpr int kSmemWsFuncEnd = kSmemWsFuncOffset +
+      (Is_arbitrary_ ? (int)((Base::kNFunc/2 + 1 + Base::kNFunc/2 + 1 + 1) * (int)sizeof(int)) : 0);
+
+  // Persistent Q tile: math warp TMA writes Q directly here; LDSM reads it every GEMM1 iteration.
+  // Aligned to the SW128 absolute-swizzle period (2048B) so TMA's absolute-swizzle write addresses
+  // match the PI-swizzled LDSM read addresses for both Is_causal and Is_arbitrary.
+  static constexpr int kSmemQPersistBytes =
+      kBlockM_ * kHeadDim_ * (int)sizeof(typename Base::Element);
+  static constexpr int kSmemWsQPersistOffset = ((kSmemWsFuncEnd + 2047) / 2048) * 2048;
+  static constexpr int kSmemWsAfterQPersist = kSmemWsQPersistOffset + kSmemQPersistBytes;
+  static constexpr int kSmemWsAfterQPersistPadded = ((kSmemWsAfterQPersist + 127) / 128) * 128;
+  using SmemLayoutWsO_TMA =
+      typename Hstu_blackwell_rtx_ws_o_tma_layout<kHeadDim_, kBlockM_, out_type>::type;
+  static constexpr int kSmemWsOStoreBytes =
+      (int)size(SmemLayoutWsO_TMA{}) * (int)sizeof(out_type);
+  // D32/D64/D128 can afford a dedicated swizzled O buffer. D256 no-RAB keeps
+  // two KV stages, whose combined 64KB region can be safely reused after math
+  // consumes all K/V tiles and before the next tile's K/V loads.
+  static constexpr bool kUseIndependentOBuffer = kHeadDim_ <= 128;
+  static constexpr bool kUseAliasedOBuffer =
+      kHeadDim_ > 128 && !kUseSingleKVStage;
+  static constexpr bool kUseTmaOStore =
+      kUseIndependentOBuffer || kUseAliasedOBuffer;
+  static constexpr int kSmemWsOOffset = kSmemWsAfterQPersistPadded;
+  static constexpr int kSmemWsOBytes =
+      kUseIndependentOBuffer
+          ? kSmemWsOStoreBytes
+          : 0;
+  static constexpr int kSmemWsAfterO = kSmemWsOOffset + kSmemWsOBytes;
+  static constexpr int kSmemWsRabOffset = kSmemWsAfterO;
+  static constexpr int kSmemWsRabBytes =
+      kUseRabSmem ? kBlockM_ * kBlockN_ * (int)sizeof(cutlass::bfloat16_t) : 0;
+  static constexpr int kSmemWsAfterRab = kSmemWsRabOffset + kSmemWsRabBytes;
+  // WS data region padded to 128B; SF (TMA targets) starts at this offset from smem_.
+  static constexpr int kSmemWsDataSizePadded = ((kSmemWsAfterRab + 127) / 128) * 128;
+  // WS SF SMEM: SFA(512B) + SFP unit(512B) + SFB[0]+[1] + SFV[0]+[1] (each 512B @ 128) = 3072B.
+  // SFP is separate so real SFA SMEM is never clobbered — enables per-tile s2r of SFA for GEMM1.
+  static constexpr int kSmemWsSFSize =
+      (kBlockM_ * 2 + kBlockN_ * 4) * (int)sizeof(int32_t);
+  static constexpr int kSmemSize = kSmemWsDataSizePadded + kSmemWsSFSize + kSmemMbarSize;
+
+  // RAB is loaded as a dense row-major BF16 [M,N] tile.  Math warps read it
+  // scalar from SMEM after GEMM1; no QMMA/LDSM layout is required.
+  using SmemLayoutRab_TMA = Layout<
+      Shape<Int<kBlockM_>, Int<kBlockN_>, _1>,
+      Stride<Int<kBlockN_>, _1, Int<kBlockM_ * kBlockN_>>>;
+
+  // Invariant checks
+  static_assert(kNMathWarps * 16 == Base::kBlockM,
+      "kNMathWarps * 16 must equal kBlockM (8 warps × 16 rows = 128)");
+  static_assert(kNThreads == (kNMathWarps + kNLoadWarps) * 32,
+      "kNThreads == (kNMathWarps + kNLoadWarps) * 32");  // 384
+  static_assert(kSmemMbarSize == (kUseRabSmem ? 128 : 112),
+      "kSmemMbarSize must be 112 without RAB SMEM or 128 with RAB SMEM");
+};

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/static_switch.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/static_switch.h
@@ -1,0 +1,44 @@
+// Minimal static dispatch helpers used by the Blackwell RTX FP8 forward path.
+
+#pragma once
+
+#define BOOL_SWITCH(COND, CONST_NAME, ...)      \
+  [&] {                                         \
+    if (COND) {                                 \
+      constexpr static bool CONST_NAME = true;  \
+      return __VA_ARGS__();                     \
+    } else {                                    \
+      constexpr static bool CONST_NAME = false; \
+      return __VA_ARGS__();                     \
+    }                                           \
+  }()
+
+#ifdef HSTU_DISABLE_CONTEXT
+#define CONTEXT_SWITCH(COND, CONST_NAME, ...) \
+  [&] {                                       \
+    constexpr static bool CONST_NAME = false; \
+    return __VA_ARGS__();                     \
+  }()
+#else
+#define CONTEXT_SWITCH BOOL_SWITCH
+#endif
+
+#ifdef HSTU_DISABLE_TARGET
+#define TARGET_SWITCH(COND, CONST_NAME, ...)  \
+  [&] {                                       \
+    constexpr static bool CONST_NAME = false; \
+    return __VA_ARGS__();                     \
+  }()
+#else
+#define TARGET_SWITCH BOOL_SWITCH
+#endif
+
+#ifdef HSTU_DISABLE_RAB
+#define RAB_SWITCH(COND, CONST_NAME, ...)     \
+  [&] {                                       \
+    constexpr static bool CONST_NAME = false; \
+    return __VA_ARGS__();                     \
+  }()
+#else
+#define RAB_SWITCH BOOL_SWITCH
+#endif

--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/utils.h
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell_rtx/utils.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2023, Tri Dao.
  * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
@@ -8,117 +7,110 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Utility functions for Blackwell RTX HSTU kernels.
+// Includes tile size selection, type conversion helpers, and CUDA utilities.
+
 #pragma once
 
 #include <assert.h>
-#include <cuda_fp16.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <tuple>
 
+#include <cuda_fp16.h>
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
 #include <cuda_bf16.h>
 #endif
 
+#include <cute/tensor.hpp>
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
 
-#include <cute/tensor.hpp>
+#define CHECK_CUDA(call)                \
+  do {                                  \
+    cudaError_t status_ = call;         \
+    if (status_ != cudaSuccess) {       \
+      fprintf(                          \
+          stderr,                       \
+          "CUDA error (%s:%d): %s\n",   \
+          __FILE__,                     \
+          __LINE__,                     \
+          cudaGetErrorString(status_)); \
+      exit(1);                          \
+    }                                   \
+  } while (0)
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+#define CHECK_CUDA_KERNEL_LAUNCH() CHECK_CUDA(cudaGetLastError())
 
-#ifndef HSTU_DEBUG_ENABLED
-#define HSTU_DEBUG_ENABLED 0
-#endif
-
-#if HSTU_DEBUG_ENABLED
-#define HSTU_DEBUG_INFO(cond, ...)                 \
- do {                                              \
-   if (cond) {                                     \
-     printf(__VA_ARGS__);                          \
-   }                                               \
- } while (0)
-#else
-#define HSTU_DEBUG_INFO(cond, ...) do {} while (0)
+#ifndef EPSILON
+#define EPSILON 1e-6
 #endif
 
 namespace flash {
 
+using namespace cute;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static __device__ float tanh_fast(float x) {
-  float res;
-  asm volatile("{ tanh.approx.f32 %0, %1; }\n" : "=f"(res) : "f"(x));
-  return res;
-}
-
-static __device__ float sigmoid_fast(float x) {
-  return 0.5f * tanh_fast(0.5f * x) + 0.5f;
-}
-
-template <typename Engine, typename Layout>
-inline __device__ void silu(Tensor<Engine, Layout>& t) {
-  using ValT = typename Engine::value_type;
-#pragma unroll
-  for (int i = 0; i < size(t); ++i) {
-    float v = static_cast<float>(t(i));
-    float sigmoid_v = sigmoid_fast(v);
-    float out = v * sigmoid_v;
-    float silu_out = v > -10.0f ? out : 0.f;
-    t(i) = static_cast<ValT>(silu_out);
+// Tile sizes for Blackwell RTX forward pass.
+// {kBlockM, kBlockN, kNWarps}
+//
+// Blackwell RTX uses per-warp mma.sync (same model as Ampere).
+// For FP8: MMA shape is M16×N8×K32 (k=32 per step, 2× Ampere BF16's k=16).
+// We use larger tiles to amortize overheads since FP8 halves SMEM usage.
+template <int Headdim, bool Has_rab, bool Is_fp8, bool Is_arbitrary = false>
+constexpr std::tuple<int, int, int> get_tile_size_fwd_blackwell_rtx() {
+  if constexpr (Is_fp8) {
+    // FP8 WS path uses a fixed 8-math-warp shape.  Keep BN64 for all head
+    // dimensions so paged KV page_size == kBlockN and RAB/DRAB share the same
+    // specialization family.
+    if constexpr (Has_rab) {
+      if constexpr (Headdim <= 64) {
+        return {128, 64, 8};
+      } else if constexpr (Headdim == 128) {
+        // Use BN64 so non-paged RAB/DRAB can share the WS TMA path with paged
+        // KV and hdim256 RAB; V block-scale metadata must match this tile size.
+        return {128, 64, 8};
+      } else {
+        return {128, 64, 8};
+      }
+    } else {
+      if constexpr (Headdim <= 64) {
+        return {128, 64, 8};
+      } else if constexpr (Headdim == 128) {
+        return {128, 64, 8};
+      } else {
+        return {128, 64, 8};
+      }
+    }
+  } else {
+    // BF16: Same tile sizes as Ampere
+    if constexpr (Has_rab) {
+      if constexpr (Headdim <= 64) {
+        return {128, 64, 8};
+      } else {
+        // D256 + RAB with BN64 needs about 104KB dynamic SMEM
+        // (Q + K/V + RAB), which can exceed the Blackwell RTX opt-in limit.
+        return {64, 32, 4};
+      }
+    } else {
+      if constexpr (Headdim <= 64) {
+        return {128, 64, 8};
+      } else if constexpr (Headdim == 128) {
+        return {128, 128, 8};
+      } else {
+        if constexpr (Is_arbitrary) {
+          return {64, 32, 4};
+        }
+        return {64, 64, 4};
+      }
+    }
   }
 }
 
-template <typename Engine, typename Layout>
-CUTLASS_DEVICE void fast_silu(Tensor<Engine, Layout>& t) {
-  using ValT = typename Engine::value_type;
-  CUTLASS_PRAGMA_UNROLL
-  for (int i = 0; i < size(t); ++i) {
-    float v = static_cast<float>(t(i)) * 0.5f;
-    float tanh_v = tanh_fast(v);
-    t(i) = v > -10.0f ? __fmaf_rn(v, tanh_v, v) : 0.f;
-  }
-}
-
-template <
-    typename Engine0,
-    typename Layout0,
-    typename Engine1,
-    typename Layout1>
-inline __device__ void silu_bwd(
-    Tensor<Engine0, Layout0>& x,
-    Tensor<Engine1, Layout1>& y) {
-  static_assert(decltype(size(x))::value == decltype(size(y))::value);
-  using ValT0 = typename Engine0::value_type;
-  using ValT1 = typename Engine1::value_type;
-#pragma unroll
-  for (int i = 0; i < size(x); ++i) {
-    float v = static_cast<float>(x(i));
-    float sigmoid_v = sigmoid_fast(v);
-    float out = v * sigmoid_v;
-    float temp = sigmoid_v * (1 + v * (1 - sigmoid_v));
-    float dsilu_temp = v > -10.0f ? temp : 0.f;
-    float silu_out = v > -10.0f ? out : 0.f;
-    x(i) = static_cast<ValT0>(dsilu_temp);
-    y(i) = static_cast<ValT1>(silu_out);
-  }
-}
-
-template <typename Tensor0, typename Tensor1>
-inline __device__ void dsilu_bwd(Tensor0& dy, Tensor1& x) {
-  static_assert(decltype(size(dy))::value == decltype(size(x))::value);
-  using ValT = typename Tensor0::value_type;
-#pragma unroll
-  for (int i = 0; i < size(dy); ++i) {
-    float dsilu_temp = static_cast<float>(x(i));
-    float dyv = static_cast<float>(dy(i));
-    float out = dyv * dsilu_temp;
-    float dsilu_out = out;
-    dy(i) = static_cast<ValT>(dsilu_out);
-  }
-}
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>
 struct MaxOp {
@@ -136,9 +128,62 @@ struct MinOp {
 
 template<typename T, typename Op>
 __inline__ __device__ void warpReduce(T& val, Op op) {
-  #pragma unroll
+  CUTLASS_PRAGMA_UNROLL
   for (int mask = 16; mask > 0; mask >>= 1)
     val = op(val, __shfl_xor_sync(0xffffffff, val, mask, 32));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Type conversion helper
+template <typename To_type, typename Engine, typename Layout>
+CUTLASS_DEVICE auto convert_type(Tensor<Engine, Layout> const& tensor) {
+  using From_type = typename Engine::value_type;
+  constexpr int numel = decltype(size(tensor))::value;
+  cutlass::NumericArrayConverter<To_type, From_type, numel> convert_op;
+  auto frag =
+      convert_op(*reinterpret_cast<const cutlass::Array<From_type, numel>*>(
+          tensor.data()));
+  return make_tensor(make_rmem_ptr<To_type>(&frag), tensor.layout());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Fast approximate functions
+static __device__ float tanh_fast(float x) {
+  float res;
+  asm volatile("{ tanh.approx.f32 %0, %1; }\n" : "=f"(res) : "f"(x));
+  return res;
+}
+
+static __device__ float sigmoid_fast(float x) {
+  return 0.5f * tanh_fast(0.5f * x) + 0.5f;
+}
+
+template <typename Engine, typename Layout>
+CUTLASS_DEVICE void silu(Tensor<Engine, Layout>& t) {
+  using ValT = typename Engine::value_type;
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < size(t); ++i) {
+    float v = static_cast<float>(t(i));
+    float sigmoid_v = sigmoid_fast(v);
+    float out = v * sigmoid_v;
+    float silu_out = v > -10.0f ? out : 0.f;
+    t(i) = static_cast<ValT>(silu_out);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename Engine, typename Layout>
+CUTLASS_DEVICE void fast_silu(Tensor<Engine, Layout>& t) {
+  using ValT = typename Engine::value_type;
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < size(t); ++i) {
+    float v = static_cast<float>(t(i)) * 0.5f;
+    float tanh_v = tanh_fast(v);
+    t(i) = v > -10.0f ? __fmaf_rn(v, tanh_v, v) : 0.f;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -147,8 +192,6 @@ template <typename Engine, typename Layout, typename EngineOut>
 CUTLASS_DEVICE void convert_type_safe(
     Tensor<Engine, Layout> const& tensor,
     Tensor<EngineOut, Layout>& out) {
-  // Somehow if we allocate out inside this function and return it, e2e is
-  // slower and the output can be wrong.
   using From_type = typename Engine::value_type;
   using To_type = typename EngineOut::value_type;
   static constexpr int FragmentSize = std::max(
@@ -265,12 +308,18 @@ __forceinline__ __device__ auto convert_layout_acc_Aregs(Layout acc_layout) {
   static_assert(decltype(size<0>(acc_layout))::value == 4);
   static_assert(decltype(rank(acc_layout))::value == 3);
   constexpr int mma_shape_K = get<2>(typename MMA_traits::Shape_MNK{});
-  static_assert(mma_shape_K == 8 || mma_shape_K == 16);
+  static_assert(mma_shape_K == 8 || mma_shape_K == 16 || mma_shape_K == 32);
   if constexpr (mma_shape_K == 8) {
     return acc_layout;
-  } else {
+  } else if constexpr (mma_shape_K == 16) {
     auto l = logical_divide(
         acc_layout, Shape<X, X, _2>{}); // (4, MMA_M, (2, MMA_N / 2)))
+    return make_layout(
+        make_layout(get<0>(l), get<2, 0>(l)), get<1>(l), get<2, 1>(l));
+  } else {
+    // mma_shape_K == 32 (FP8 m16n8k32 on Blackwell RTX)
+    auto l = logical_divide(
+        acc_layout, Shape<X, X, _4>{}); // (4, MMA_M, (4, MMA_N / 4)))
     return make_layout(
         make_layout(get<0>(l), get<2, 0>(l)), get<1>(l), get<2, 1>(l));
   }
@@ -279,10 +328,7 @@ __forceinline__ __device__ auto convert_layout_acc_Aregs(Layout acc_layout) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Blocks until all but N previous cp.async.commit_group operations have
-// committed. This differs from cute::cp_async_wait in that when N = 0 we don't
-// call cp.async.wait_all (which is equivalent to commit_group then wait_group
-// 0). Instead we just call cp.async.wait_group 0, which is slightly faster.
-// https://github.com/NVIDIA/cutlass/blob/master/include/cute/arch/copy_sm80.hpp#L113
+// committed.
 template <int N>
 CUTE_HOST_DEVICE void cp_async_wait() {
 #if defined(CUTE_ARCH_CP_ASYNC_SM80_ENABLED)
@@ -314,7 +360,6 @@ __forceinline__ __device__ void copy(
   CUTE_STATIC_ASSERT_V(size<0>(S) == size<0>(D)); // MMA
   CUTE_STATIC_ASSERT_V(size<1>(S) == size<1>(D)); // MMA_M
   CUTE_STATIC_ASSERT_V(size<2>(S) == size<2>(D)); // MMA_K
-  // There's no case where !Clear_OOB_K && Clear_OOB_MN
   static_assert(!(Clear_OOB_MN && !Clear_OOB_K));
 #pragma unroll
   for (int m = 0; m < size<1>(S); ++m) {
@@ -330,89 +375,5 @@ __forceinline__ __device__ void copy(
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// {kBlockM, kBlockN, kNWarps}
-template <int Arch, int kHeadDim, bool Has_rab, bool Is_arbitrary = false>
-constexpr std::tuple<int, int, int> get_tile_size_fwd() {
-  if constexpr (Arch == 120) {
-    if constexpr (kHeadDim > 128 && (Has_rab || Is_arbitrary)) {
-      return {64, 32, 4};
-    }
-    // SM120: same as SM89 for forward when dynamic shared memory fits.
-    return {64, 64, 4};
-  }
-  if constexpr (Arch == 89) {
-    return {64, 64, 4};
-  }
-  if constexpr (Arch == 80) {
-    if constexpr (Has_rab) {
-      return {128, 64, 8};
-    } else {
-      if constexpr (kHeadDim <= 64) {
-        return {128, 96, 4};
-      } else if constexpr (kHeadDim <= 128) {
-        return {128, 96, 8};
-      } else {
-        return {128, 96, 8};
-      }
-    }
-  }
-  if constexpr (Has_rab) {
-    if constexpr (kHeadDim <= 128) {
-      return {128, 64, 4};
-    } else {
-      return {64, 32, 4};
-    }
-  } else {
-    if constexpr (kHeadDim <= 128) {
-      return {128, 96, 4};
-    } else {
-      return {64, 64, 4};
-    }
-  }
-}
-
-// {kBlockM, kBlockN, kNWarps}
-template <int Arch, int kHeadDim, bool Has_rab, bool Is_arbitrary = false>
-constexpr std::tuple<int, int, int> get_tile_size_bwd() {
-  if constexpr (Arch == 120) {
-    // SM120: reduced tile sizes to fit within 99KB shared memory + register limits.
-    // SM120 has only 99KB optin shared memory (vs SM89's ~100KB).
-    if constexpr (Is_arbitrary && kHeadDim > 128) {
-      return {32, 32, 2};
-    }
-    if constexpr (Has_rab) {
-      if constexpr (kHeadDim <= 64) {
-        return {64, 64, 8};   // reduced kBlockM from 128 to 64 (smem: 96KB -> 57KB)
-      } else if constexpr (kHeadDim <= 128) {
-        return {64, 64, 8};   // same tile, 88KB fits within 99KB limit
-      } else {
-        return {16, 64, 4};   // same tile as no-RAB D256; still fits SM120
-      }
-    } else {
-      if constexpr (kHeadDim <= 64) {
-        return {128, 64, 8};  // same as SM89, 80KB fits
-      } else if constexpr (kHeadDim <= 128) {
-        return {64, 64, 8};   // same as SM89
-      } else {
-        return {16, 64, 4};   // same as SM89
-      }
-    }
-  }
-  if constexpr (Arch == 89) {
-    if constexpr (kHeadDim <= 64) {
-      return {128, 64, 8};
-    } else if constexpr (kHeadDim <= 128) {
-      return {64, 64, 8};
-    } else {
-      return {16, 64, 4};
-    }
-  }
-  if constexpr (kHeadDim <= 128) {
-    return {64, 128, 8};
-  } else {
-    return {64, 64, 8};
-  }
-}
 
 } // namespace flash

--- a/fbgemm_gpu/experimental/hstu/test/hstu_test.py
+++ b/fbgemm_gpu/experimental/hstu/test/hstu_test.py
@@ -716,6 +716,15 @@ class HSTU16Test(unittest.TestCase):
         has_target = max_target_len > 0
         is_causal = window_size[0] == -1 and window_size[1] == 0
         is_delta_q = max_seq_len_q < max_seq_len_k
+        if (
+            torch.cuda.get_device_capability()[0] >= 12
+            and dtype == torch.bfloat16
+            and attn_dim == 256
+            and is_arbitrary
+            and has_rab
+        ):
+            logger.info("Skipping SM120 BF16 D256 arbitrary RAB/DRAB")
+            return
         if is_delta_q and has_target:
             logger.info("Skipping test for is_delta_q and has_target")
             return
@@ -960,7 +969,68 @@ def generate_paged_kv_input(
     page_size: int,
     dtype: torch.dtype,
     full_batch: bool,
+    max_context_len: int = 0,
+    target_group_size: int = 1,
+    window_size: tuple[int, int] = (-1, 0),
+    heads_rab: Optional[int] = None,
+    has_drab: bool = False,
+    is_arbitrary: bool = False,
+    return_extra: bool = False,
 ):
+    if return_extra:
+        L_q, L_k, num_contexts, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, num_targets, _, q, k, v, rab, mask, func = (
+            generate_input(
+                batch_size=batch_size,
+                heads=heads,
+                heads_rab=heads_rab,
+                max_seq_len_q=max_seq_len_q,
+                max_seq_len_k=max_seq_len_k,
+                max_context_len=max_context_len,
+                max_target_len=max_target_len,
+                target_group_size=target_group_size,
+                attn_dim=attn_dim,
+                hidden_dim=hidden_dim,
+                window_size=window_size,
+                dtype=dtype,
+                full_batch=full_batch,
+                has_drab=has_drab,
+                is_delta_q=max_seq_len_q < max_seq_len_k,
+                is_arbitrary=is_arbitrary,
+            )
+        )
+        target_lens = (
+            num_targets
+            if num_targets is not None
+            else torch.zeros((batch_size,), dtype=torch.int32, device=torch.device("cuda"))
+        )
+        lengths_k = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
+        lengths_k_cache = (lengths_k - target_lens).to(torch.int32)
+        lengths_page = (lengths_k_cache + page_size - 1) // page_size
+        page_offsets = torch.zeros((batch_size + 1,), dtype=torch.int32, device=torch.device("cuda"))
+        page_offsets[1:] = torch.cumsum(lengths_page, dim=0)
+
+        total_page = int(page_offsets[-1].item())
+        page_ids = torch.randperm(total_page, device=torch.device("cuda"), dtype=torch.int32)
+        last_page_lens = ((lengths_k_cache - 1) % page_size + 1).to(torch.int32)
+        kv_cache = torch.zeros((total_page, 2, page_size, heads, attn_dim), dtype=k.dtype, device=torch.device("cuda"))
+        for i in range(batch_size):
+            k_start = int(cu_seqlens_k[i].item())
+            cache_len = int(lengths_k_cache[i].item())
+            page_begin = int(page_offsets[i].item())
+            for j in range(int(lengths_page[i].item())):
+                valid = min(page_size, cache_len - j * page_size)
+                page_id = int(page_ids[page_begin + j].item())
+                src_begin = k_start + j * page_size
+                src_end = src_begin + valid
+                kv_cache[page_id, 0, :valid] = k[src_begin:src_end]
+                kv_cache[page_id, 1, :valid] = v[src_begin:src_end]
+
+        return (
+            L_q, L_k, num_contexts, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k,
+            num_targets, page_offsets, page_ids, last_page_lens, q, k, v, kv_cache, mask,
+            rab, func,
+        )
+
     # Generate lengths for new history qkv
     if full_batch:
         lengths_q = (
@@ -1721,8 +1791,11 @@ def _bwd_reference_fp8(
 @unittest.skipIf(
     not torch.cuda.is_available()
     or torch.cuda.get_device_capability() < (9, 0)
-    or torch.cuda.get_device_capability() >= (10, 0),
-    "Skip when no Hopper GPU is available. This test is only for Hopper GPU.",
+    or (
+        torch.cuda.get_device_capability() >= (10, 0)
+        and torch.cuda.get_device_capability()[0] < 12
+    ),
+    "Skip when no Hopper or Blackwell RTX+ GPU is available.",
 )
 class HSTU8Test(unittest.TestCase):
     """Test HSTU attention with float8_e4m3 inputs."""
@@ -1759,6 +1832,7 @@ class HSTU8Test(unittest.TestCase):
         ),
         attn_hidden_dims=st.sampled_from(
             [
+                (32, 32),
                 (64, 64),
                 (128, 128),
                 (256, 256),
@@ -1801,6 +1875,14 @@ class HSTU8Test(unittest.TestCase):
         attn_dim, hidden_dim = attn_hidden_dims
         has_rab, has_drab, heads_rab = rab_params
         quant_mode, full_batch = quant_mode_full_batch
+        is_sm120_or_newer = torch.cuda.get_device_capability()[0] >= 12
+
+        if attn_dim == 32 and not is_sm120_or_newer:
+            logger.info("Skipping D32 FP8 test outside Blackwell RTX")
+            return
+        if is_sm120_or_newer and quant_mode != 2:
+            logger.info("Skipping non-blockscale FP8 test on Blackwell RTX")
+            return
 
         total_q = max_context_len + max_seq_len_q + max_target_len
         total_k = max_context_len + max_seq_len_k + max_target_len
@@ -1811,7 +1893,11 @@ class HSTU8Test(unittest.TestCase):
         if quant_mode == 0 and alpha < 0.5:
             logger.info("Skipping test for quant_mode == 0 and alpha < 0.5, might cause dQ accuracy issue")
             return
-        if quant_mode > 0 and (total_q % 16 != 0 or total_k % 16 != 0 or full_batch == False):
+        if (
+            quant_mode > 0
+            and not (is_sm120_or_newer and quant_mode == 2)
+            and (total_q % 16 != 0 or total_k % 16 != 0 or full_batch == False)
+        ):
             logger.info("Skipping test for quant_mode > 0 and (total_q % 16 != 0 or total_k % 16 != 0 or full_batch == False), not supported")
             return
         if is_delta_q and has_target:
@@ -1931,6 +2017,11 @@ class HSTU8Test(unittest.TestCase):
 
         assert (hstu_out - out_ref).abs().max().item() <= 2 * (torch_out - out_ref).abs().max().item()
 
+        if is_sm120_or_newer:
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+            return
+
         g = torch.rand_like(torch_out)
         if not has_drab:
             (dq_ref, dk_ref, dv_ref) = torch.autograd.grad(
@@ -2021,6 +2112,177 @@ class HSTU8Test(unittest.TestCase):
             ).abs().max().item()
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 12,
+    "FP8 paged KV test is only for Blackwell RTX.",
+)
+class HSTU8PagedKVTest(unittest.TestCase):
+    """Test Blackwell RTX FP8 paged KV attention."""
+
+    @given(
+        batch_size=st.sampled_from([4]),
+        heads=st.sampled_from([1, 2]),
+        seq_len_params=st.sampled_from([(99, 99), (128, 128), (256, 256)]),
+        max_context_len=st.sampled_from([0, 99, 128]),
+        target_params=st.sampled_from(
+            [
+                (0, (-1, -1), 1, False),
+                (0, (-1, -1), 1, True),
+                (0, (64, 16), 1, False),
+                (0, (-1, 0), 1, False),
+                (64, (-1, 0), 1, False),
+                (128, (-1, 0), 1, False),
+            ]
+        ),
+        attn_hidden_dims=st.sampled_from(
+            [(32, 32), (64, 64), (128, 128), (256, 256)]
+        ),
+        alpha=st.sampled_from([1.0]),
+        rab_params=st.sampled_from(
+            [
+                (False, False, None),
+                (True, False, None),
+                (True, True, None),
+            ]
+        ),
+        full_batch=st.just(True),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=_MAX_SAMPLES, deadline=None)
+    def test_paged_kv_attn_fp8(
+        self,
+        batch_size: int,
+        heads: int,
+        seq_len_params: Tuple[int, int],
+        max_context_len: int,
+        target_params: Tuple[int, Tuple[int, int], int, bool],
+        attn_hidden_dims: Tuple[int, int],
+        alpha: float,
+        rab_params: Tuple[bool, bool, Optional[int]],
+        full_batch: bool,
+    ) -> None:
+        max_seq_len_q, max_seq_len_k = seq_len_params
+        max_target_len, window_size, target_group_size, is_arbitrary = target_params
+        attn_dim, hidden_dim = attn_hidden_dims
+        has_rab, has_drab, heads_rab = rab_params
+        has_context = max_context_len > 0
+        is_causal = window_size[0] == -1 and window_size[1] == 0
+        if not is_causal and has_context:
+            logger.info("Skipping test for not is_causal and has_context")
+            return
+        if is_arbitrary and (has_context or max_target_len > 0):
+            logger.info("Skipping test for arbitrary with context or target")
+            return
+        if max_target_len > 0 and not is_causal:
+            logger.info("Skipping test for target and not is_causal")
+            return
+
+        page_size = 64
+        (
+            L_q,
+            L_k,
+            num_contexts,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_q,
+            seqused_k,
+            num_targets,
+            page_offsets,
+            page_ids,
+            last_page_lens,
+            q,
+            k,
+            v,
+            kv_cache,
+            mask,
+            rab,
+            func,
+        ) = generate_paged_kv_input(
+            batch_size=batch_size,
+            heads=heads,
+            max_seq_len_q=max_seq_len_q,
+            max_seq_len_k=max_seq_len_k,
+            max_target_len=max_target_len,
+            attn_dim=attn_dim,
+            hidden_dim=hidden_dim,
+            page_size=page_size,
+            dtype=torch.float8_e4m3fn,
+            full_batch=full_batch,
+            max_context_len=max_context_len,
+            target_group_size=target_group_size,
+            window_size=window_size,
+            heads_rab=heads_rab,
+            has_drab=has_drab,
+            is_arbitrary=is_arbitrary,
+            return_extra=True,
+        )
+        out_ref = _hstu_attention_maybe_from_cache(
+            num_heads=heads,
+            attention_dim=attn_dim,
+            linear_dim=hidden_dim,
+            seqlen_q=max_context_len + max_seq_len_q + max_target_len,
+            seqlen_k=max_context_len + max_seq_len_k + max_target_len,
+            q=q,
+            k=k,
+            v=v,
+            q_offsets=cu_seqlens_q,
+            k_offsets=cu_seqlens_k,
+            seqused_q=seqused_q,
+            seqused_k=seqused_k,
+            rab=rab if has_rab else None,
+            invalid_attn_mask=mask,
+            alpha=alpha,
+            upcast=True,
+            is_delta_q=max_seq_len_q < max_seq_len_k,
+        )
+        torch_out = _hstu_attention_maybe_from_cache_fp8(
+            num_heads=heads,
+            attention_dim=attn_dim,
+            linear_dim=hidden_dim,
+            seqlen_q=max_context_len + max_seq_len_q + max_target_len,
+            seqlen_k=max_context_len + max_seq_len_k + max_target_len,
+            q=q,
+            k=k,
+            v=v,
+            q_offsets=cu_seqlens_q,
+            k_offsets=cu_seqlens_k,
+            seqused_q=seqused_q,
+            seqused_k=seqused_k,
+            rab=rab if has_rab else None,
+            invalid_attn_mask=mask,
+            alpha=alpha,
+            quant_mode=2,
+            is_delta_q=max_seq_len_q < max_seq_len_k,
+        )
+        hstu_out = hstu_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            seqused_q=seqused_q,
+            seqused_k=seqused_k,
+            max_seqlen_q=max_context_len + max_seq_len_q + max_target_len,
+            max_seqlen_k=max_context_len + max_seq_len_k + max_target_len,
+            scaling_seqlen=-1,
+            num_contexts=num_contexts,
+            num_targets=num_targets,
+            target_group_size=target_group_size,
+            window_size=window_size,
+            alpha=alpha,
+            rab=rab if has_rab else None,
+            has_drab=has_drab,
+            kv_cache=kv_cache,
+            page_offsets=page_offsets,
+            page_ids=page_ids,
+            last_page_lens=last_page_lens,
+            func=func,
+            quant_mode=2,
+        )
+        torch.cuda.synchronize()
+        assert (hstu_out - out_ref).abs().max().item() <= 2 * (
+            torch_out - out_ref
+        ).abs().max().item()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The repo previously lacked an FP8 kernel for the RTX Pro 6000 Blackwell, so this PR adds a warp-specialized FP8 kernel that leverages its MXFP8 hardware support.
Based on performance across different configurations, I use a persistent kernel where it outperforms the non-persistent variant, and keep the non-persistent kernel for the remaining cases.