### PR TITLE
Fix Blackwell HSTU dQ workspace offset overflow

### DIFF
--- a/fbgemm_gpu/experimental/hstu/src/hstu_blackwell/hstu_bwd.py
+++ b/fbgemm_gpu/experimental/hstu/src/hstu_blackwell/hstu_bwd.py
@@ -50,7 +50,7 @@ from cutlass.cute.runtime import from_dlpack
 from cutlass.cute.typing import Int32, Float32, Float8E4M3FN, Float16, BFloat16, Boolean
 
 from .mask import AttentionMask
-from .utils import split_wg, tanhf, mul_packed_f32x2, fma_packed_f32x2, sub_packed_f32x2, add_packed_f32x2
+from .utils import split_wg, tanhf, mul_packed_f32x2, fma_packed_f32x2, sub_packed_f32x2, add_packed_f32x2, domain_offset_i64
 from .fast_math import FastSilU
 from .block_info import BWDBlockInfo
 from .seqlen_info import SeqlenInfo
@@ -1106,7 +1106,8 @@ class HSTUAttentionBackwardSm100:
         for idx_s_t in cutlass.range(tidy, self.block_seq, self.num_threads_seq):
             idx_s = idx_s_t + self.block_seq * bidz
             if idx_s < seqlen:
-                dQ_acc_bhs = dQ_acc[idx_s, None, (bidx, bidy)]
+                dQ_acc_batch = domain_offset_i64((0, 0, ((0, 0), bidy)), dQ_acc)
+                dQ_acc_bhs = dQ_acc_batch[idx_s, None, (bidx, 0)]
                 dQ_acc_bhs = cute.logical_divide(
                     dQ_acc_bhs, cute.make_layout(self.convert_elem_per_load)
                 )


### PR DESCRIPTION
## Summary

Fix a Blackwell HSTU backward illegal memory access in the final `dQ_acc` to `dQ` convert kernel when the FP32 workspace crosses the signed 32-bit element-offset boundary.

`dQ_acc` is a manually constructed workspace tensor. Its batch stride is `D * Q * H`, derived from `Int32` problem-shape values. For large perf-sweep shapes, the convert kernel can index batch 256 at exactly `2^31` FP32 elements, causing signed 32-bit offset wrap and an invalid global read before the workspace allocation.

This patch uses the existing `domain_offset_i64()` helper to move the `dQ_acc` base pointer to the current batch with 64-bit pointer arithmetic, then performs local `(seq, head, dim)` indexing within that batch.

Fixes https://github.com/jiayus-nvidia/FBGEMM/issues/14

## Validation

On OCI-HSG GB200 with `gitlab-master.nvidia.com/devtech-compute/distributed-recommender:devel_base_arm64_57344935`:

- `compute-sanitizer --tool memcheck` passes with 0 errors for `B=257, S=16384, H=4, D=128`.
- Backward-only repro passes for:
  - `B=512, S=16384, H=4, D=128`
  - `B=512, S=16384, H=8, D=64`
  - `B=256, S=16384, H=8, D=128`
- Perf spot check on `B=128, S=8192, H=4, D=128` backward-only:
  - original median: `21.4166 ms`
  - patched median: `21.4686 ms`

The `dQ` store path was also checked with sanitizer. It does not need the same change: `dQ` comes from the DLPack/TVM FFI tensor argument path with 64-bit stride descriptors, while the overflow is specific to the manually constructed `dQ_acc` workspace layout.
